### PR TITLE
feat(elixir): add GitHub Issues tracker adapter

### DIFF
--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -52,6 +52,8 @@ defmodule SymphonyElixir.Config.Schema do
       field(:assignee, :string)
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
+      field(:repo, :string)
+      field(:labels_prefix, :string, default: "")
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -59,7 +61,7 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :active_states, :terminal_states],
+        [:kind, :endpoint, :api_key, :project_slug, :assignee, :active_states, :terminal_states, :repo, :labels_prefix],
         empty_values: []
       )
     end
@@ -366,10 +368,16 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp finalize_settings(settings) do
+    {api_key_fallback_env, assignee_fallback_env} =
+      case settings.tracker.kind do
+        "github" -> {"GITHUB_TOKEN", "GITHUB_ASSIGNEE"}
+        _ -> {"LINEAR_API_KEY", "LINEAR_ASSIGNEE"}
+      end
+
     tracker = %{
       settings.tracker
-      | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
-        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
+      | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env(api_key_fallback_env)),
+        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env(assignee_fallback_env))
     }
 
     workspace = %{

--- a/elixir/lib/symphony_elixir/github/adapter.ex
+++ b/elixir/lib/symphony_elixir/github/adapter.ex
@@ -39,9 +39,8 @@ defmodule SymphonyElixir.Github.Adapter do
         new_label = Client.state_name_to_label(state_name, labels_prefix)
 
         with :ok <- remove_state_labels(issue_id, current_state_labels),
-             :ok <- ensure_open(issue_id),
-             :ok <- add_state_label(issue_id, new_label) do
-          :ok
+             :ok <- ensure_open(issue_id) do
+          add_state_label(issue_id, new_label)
         end
     end
   end

--- a/elixir/lib/symphony_elixir/github/adapter.ex
+++ b/elixir/lib/symphony_elixir/github/adapter.ex
@@ -1,0 +1,95 @@
+defmodule SymphonyElixir.Github.Adapter do
+  @moduledoc """
+  GitHub Issues-backed tracker adapter.
+  """
+
+  @behaviour SymphonyElixir.Tracker
+
+  alias SymphonyElixir.{Config, Github.Client}
+
+  @spec fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
+  def fetch_candidate_issues, do: client_module().fetch_candidate_issues()
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  def fetch_issues_by_states(states), do: client_module().fetch_issues_by_states(states)
+
+  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  def fetch_issue_states_by_ids(issue_ids), do: client_module().fetch_issue_states_by_ids(issue_ids)
+
+  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
+  def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
+    client_module().create_comment(issue_id, body)
+  end
+
+  @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
+  def update_issue_state(issue_id, state_name)
+      when is_binary(issue_id) and is_binary(state_name) do
+    tracker = Config.settings!().tracker
+    labels_prefix = tracker.labels_prefix || ""
+
+    current_state_labels = state_labels_for_issue(issue_id)
+
+    case String.downcase(String.trim(state_name)) do
+      terminal when terminal in ["done", "closed"] ->
+        with :ok <- remove_state_labels(issue_id, current_state_labels) do
+          client_module().update_issue(issue_id, %{state: "closed"})
+        end
+
+      _ ->
+        new_label = Client.state_name_to_label(state_name, labels_prefix)
+
+        with :ok <- remove_state_labels(issue_id, current_state_labels),
+             :ok <- ensure_open(issue_id),
+             :ok <- add_state_label(issue_id, new_label) do
+          :ok
+        end
+    end
+  end
+
+  defp state_labels_for_issue(issue_id) do
+    tracker = Config.settings!().tracker
+    labels_prefix = tracker.labels_prefix || ""
+    all_known_labels = known_state_labels(labels_prefix)
+
+    case client_module().fetch_issue_states_by_ids([issue_id]) do
+      {:ok, [issue | _]} ->
+        Enum.filter(issue.labels, fn label ->
+          MapSet.member?(all_known_labels, label)
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp known_state_labels(labels_prefix) do
+    ["todo", "in-progress", "human-review"]
+    |> Enum.map(fn base -> String.downcase(labels_prefix <> base) end)
+    |> MapSet.new()
+  end
+
+  defp remove_state_labels(_issue_id, []), do: :ok
+
+  defp remove_state_labels(issue_id, labels) do
+    Enum.reduce_while(labels, :ok, fn label, :ok ->
+      case client_module().remove_label(issue_id, label) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp ensure_open(issue_id) do
+    client_module().update_issue(issue_id, %{state: "open"})
+  end
+
+  defp add_state_label(_issue_id, nil), do: :ok
+
+  defp add_state_label(issue_id, label) do
+    client_module().add_labels(issue_id, [label])
+  end
+
+  defp client_module do
+    Application.get_env(:symphony_elixir, :github_client_module, Client)
+  end
+end

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -1,0 +1,451 @@
+defmodule SymphonyElixir.Github.Client do
+  @moduledoc """
+  GitHub REST API client for polling issues and managing state.
+  """
+
+  require Logger
+  alias SymphonyElixir.{Config, Linear.Issue}
+
+  @issues_per_page 100
+  @max_error_body_log_bytes 1_000
+  @rate_limit_warning_threshold 100
+
+  @state_label_map %{
+    "todo" => "Todo",
+    "in-progress" => "In Progress",
+    "in progress" => "In Progress",
+    "human-review" => "Human Review",
+    "human review" => "Human Review"
+  }
+
+  @spec fetch_candidate_issues() :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_candidate_issues do
+    tracker = Config.settings!().tracker
+
+    cond do
+      is_nil(tracker.api_key) ->
+        {:error, :missing_github_api_token}
+
+      is_nil(tracker.repo) ->
+        {:error, :missing_github_repo}
+
+      true ->
+        fetch_issues_by_state_labels(tracker, tracker.active_states)
+    end
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(state_names) when is_list(state_names) do
+    normalized_states = state_names |> Enum.map(&to_string/1) |> Enum.uniq()
+
+    if normalized_states == [] do
+      {:ok, []}
+    else
+      tracker = Config.settings!().tracker
+
+      cond do
+        is_nil(tracker.api_key) ->
+          {:error, :missing_github_api_token}
+
+        is_nil(tracker.repo) ->
+          {:error, :missing_github_repo}
+
+        true ->
+          fetch_issues_by_state_labels(tracker, normalized_states)
+      end
+    end
+  end
+
+  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issue_states_by_ids(issue_ids) when is_list(issue_ids) do
+    ids = Enum.uniq(issue_ids)
+
+    case ids do
+      [] ->
+        {:ok, []}
+
+      ids ->
+        tracker = Config.settings!().tracker
+
+        cond do
+          is_nil(tracker.api_key) ->
+            {:error, :missing_github_api_token}
+
+          is_nil(tracker.repo) ->
+            {:error, :missing_github_repo}
+
+          true ->
+            fetch_issues_by_numbers(tracker, ids)
+        end
+    end
+  end
+
+  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
+  def create_comment(issue_number, body) when is_binary(issue_number) and is_binary(body) do
+    tracker = Config.settings!().tracker
+
+    case api_request(:post, "/repos/#{tracker.repo}/issues/#{issue_number}/comments", %{body: body}) do
+      {:ok, %{status: 201}} -> :ok
+      {:ok, response} -> {:error, {:github_api_status, response.status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec add_labels(String.t(), [String.t()]) :: :ok | {:error, term()}
+  def add_labels(issue_number, labels) when is_binary(issue_number) and is_list(labels) do
+    tracker = Config.settings!().tracker
+
+    case api_request(:post, "/repos/#{tracker.repo}/issues/#{issue_number}/labels", %{labels: labels}) do
+      {:ok, %{status: 200}} -> :ok
+      {:ok, response} -> {:error, {:github_api_status, response.status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec remove_label(String.t(), String.t()) :: :ok | {:error, term()}
+  def remove_label(issue_number, label) when is_binary(issue_number) and is_binary(label) do
+    tracker = Config.settings!().tracker
+    encoded_label = URI.encode(label, &URI.char_unreserved?/1)
+
+    case api_request(:delete, "/repos/#{tracker.repo}/issues/#{issue_number}/labels/#{encoded_label}") do
+      {:ok, %{status: status}} when status in [200, 204] -> :ok
+      {:ok, %{status: 404}} -> :ok
+      {:ok, response} -> {:error, {:github_api_status, response.status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec update_issue(String.t(), map()) :: :ok | {:error, term()}
+  def update_issue(issue_number, attrs) when is_binary(issue_number) and is_map(attrs) do
+    tracker = Config.settings!().tracker
+
+    case api_request(:patch, "/repos/#{tracker.repo}/issues/#{issue_number}", attrs) do
+      {:ok, %{status: 200}} -> :ok
+      {:ok, response} -> {:error, {:github_api_status, response.status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec normalize_issue(map(), String.t()) :: Issue.t()
+  def normalize_issue(gh_issue, labels_prefix) when is_map(gh_issue) and is_binary(labels_prefix) do
+    number = gh_issue["number"]
+    labels = extract_labels(gh_issue)
+    state = derive_state(gh_issue, labels, labels_prefix)
+
+    %Issue{
+      id: to_string(number),
+      identifier: "##{number}",
+      title: gh_issue["title"],
+      description: gh_issue["body"],
+      priority: nil,
+      state: state,
+      branch_name: "issue-#{number}",
+      url: gh_issue["html_url"],
+      assignee_id: get_in(gh_issue, ["assignee", "login"]),
+      blocked_by: [],
+      labels: labels,
+      assigned_to_worker: true,
+      created_at: parse_datetime(gh_issue["created_at"]),
+      updated_at: parse_datetime(gh_issue["updated_at"])
+    }
+  end
+
+  defp fetch_issues_by_state_labels(tracker, state_names) do
+    labels = state_names_to_labels(state_names, tracker.labels_prefix || "")
+
+    case labels do
+      [] ->
+        fetch_all_pages(tracker, [], tracker.assignee)
+
+      labels ->
+        # GitHub's labels param uses AND logic, so we must query each label
+        # separately and merge results to get OR behavior
+        fetch_issues_by_label_union(tracker, labels)
+    end
+  end
+
+  defp fetch_issues_by_label_union(tracker, labels) do
+    results =
+      Enum.reduce_while(labels, {:ok, %{}}, fn label, {:ok, acc} ->
+        case fetch_all_pages(tracker, [label], tracker.assignee) do
+          {:ok, issues} ->
+            merged =
+              Enum.reduce(issues, acc, fn issue, map ->
+                Map.put_new(map, issue.id, issue)
+              end)
+
+            {:cont, {:ok, merged}}
+
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end)
+
+    case results do
+      {:ok, issues_map} -> {:ok, Map.values(issues_map)}
+      error -> error
+    end
+  end
+
+  defp fetch_issues_by_numbers(tracker, issue_numbers) do
+    labels_prefix = tracker.labels_prefix || ""
+
+    results =
+      Enum.reduce_while(issue_numbers, {:ok, []}, fn number, {:ok, acc} ->
+        case api_request(:get, "/repos/#{tracker.repo}/issues/#{number}") do
+          {:ok, %{status: 200, body: body}} ->
+            issue = normalize_issue(body, labels_prefix)
+            {:cont, {:ok, [issue | acc]}}
+
+          {:ok, %{status: 404}} ->
+            {:cont, {:ok, acc}}
+
+          {:ok, response} ->
+            {:halt, {:error, {:github_api_status, response.status}}}
+
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end)
+
+    case results do
+      {:ok, issues} -> {:ok, Enum.reverse(issues)}
+      error -> error
+    end
+  end
+
+  defp fetch_all_pages(tracker, labels, assignee) do
+    fetch_page(tracker, labels, assignee, 1, [])
+  end
+
+  defp fetch_page(tracker, labels, assignee, page, acc) do
+    labels_prefix = tracker.labels_prefix || ""
+
+    query_params =
+      [
+        state: "open",
+        per_page: @issues_per_page,
+        page: page,
+        sort: "created",
+        direction: "asc"
+      ]
+      |> maybe_add_labels(labels)
+      |> maybe_add_assignee(assignee)
+
+    path = "/repos/#{tracker.repo}/issues?" <> URI.encode_query(query_params)
+
+    case api_request(:get, path) do
+      {:ok, %{status: 200, body: body}} when is_list(body) ->
+        issues_only = Enum.reject(body, &Map.has_key?(&1, "pull_request"))
+
+        page_issues =
+          issues_only
+          |> Enum.map(&normalize_issue(&1, labels_prefix))
+          |> maybe_filter_assignee(assignee)
+
+        updated_acc = acc ++ page_issues
+
+        if length(body) < @issues_per_page do
+          {:ok, updated_acc}
+        else
+          fetch_page(tracker, labels, assignee, page + 1, updated_acc)
+        end
+
+      {:ok, %{status: status} = response} ->
+        Logger.error("GitHub API request failed status=#{status}#{github_error_context(response)}")
+        {:error, {:github_api_status, status}}
+
+      {:error, reason} ->
+        Logger.error("GitHub API request failed: #{inspect(reason)}")
+        {:error, {:github_api_request, reason}}
+    end
+  end
+
+  defp maybe_add_labels(params, []), do: params
+
+  defp maybe_add_labels(params, labels) do
+    Keyword.put(params, :labels, Enum.join(labels, ","))
+  end
+
+  defp maybe_add_assignee(params, nil), do: params
+  defp maybe_add_assignee(params, ""), do: params
+  defp maybe_add_assignee(params, assignee), do: Keyword.put(params, :assignee, assignee)
+
+  defp maybe_filter_assignee(issues, nil), do: issues
+  defp maybe_filter_assignee(issues, ""), do: issues
+
+  defp maybe_filter_assignee(issues, assignee) do
+    Enum.filter(issues, fn %Issue{assignee_id: aid} ->
+      is_nil(aid) or aid == assignee
+    end)
+  end
+
+  defp state_names_to_labels(state_names, labels_prefix) do
+    Enum.flat_map(state_names, fn name ->
+      label = state_name_to_label(name, labels_prefix)
+      if label, do: [label], else: []
+    end)
+  end
+
+  @doc false
+  @spec state_name_to_label(String.t(), String.t()) :: String.t() | nil
+  def state_name_to_label(state_name, labels_prefix) do
+    base =
+      case String.downcase(String.trim(state_name)) do
+        "todo" -> "todo"
+        "in progress" -> "in-progress"
+        "human review" -> "human-review"
+        "done" -> nil
+        "closed" -> nil
+        "cancelled" -> nil
+        "canceled" -> nil
+        other -> other
+      end
+
+    case base do
+      nil -> nil
+      label -> labels_prefix <> label
+    end
+  end
+
+  defp derive_state(gh_issue, labels, labels_prefix) do
+    if gh_issue["state"] == "closed" do
+      "Done"
+    else
+      find_state_from_labels(labels, labels_prefix) || "Todo"
+    end
+  end
+
+  defp find_state_from_labels(labels, labels_prefix) do
+    Enum.find_value(labels, fn label ->
+      stripped =
+        if labels_prefix != "" and String.starts_with?(label, labels_prefix) do
+          String.replace_prefix(label, labels_prefix, "")
+        else
+          label
+        end
+
+      Map.get(@state_label_map, String.downcase(stripped))
+    end)
+  end
+
+  defp extract_labels(%{"labels" => labels}) when is_list(labels) do
+    Enum.map(labels, fn
+      %{"name" => name} when is_binary(name) -> String.downcase(name)
+      label when is_binary(label) -> String.downcase(label)
+      _ -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp extract_labels(_), do: []
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(raw) when is_binary(raw) do
+    case DateTime.from_iso8601(raw) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(_), do: nil
+
+  defp api_request(method, path, body \\ nil) do
+    request_fun = request_fun()
+    request_fun.(method, path, body)
+  end
+
+  defp request_fun do
+    Application.get_env(:symphony_elixir, :github_request_fun, &default_request/3)
+  end
+
+  defp default_request(method, path, body) do
+    tracker = Config.settings!().tracker
+    url = "https://api.github.com#{path}"
+
+    headers = [
+      {"Authorization", "Bearer #{tracker.api_key}"},
+      {"Accept", "application/vnd.github+json"},
+      {"X-GitHub-Api-Version", "2022-11-28"}
+    ]
+
+    opts = [
+      headers: headers,
+      connect_options: [timeout: 30_000]
+    ]
+
+    opts = if body, do: Keyword.put(opts, :json, body), else: opts
+
+    result =
+      case method do
+        :get -> Req.get(url, opts)
+        :post -> Req.post(url, opts)
+        :patch -> Req.request(Keyword.merge(opts, url: url, method: :patch))
+        :delete -> Req.request(Keyword.merge(opts, url: url, method: :delete))
+      end
+
+    case result do
+      {:ok, response} ->
+        check_rate_limit(response)
+        {:ok, response}
+
+      {:error, reason} ->
+        {:error, {:github_api_request, reason}}
+    end
+  end
+
+  defp check_rate_limit(%{headers: headers}) do
+    remaining =
+      headers
+      |> Enum.find_value(fn
+        {"x-ratelimit-remaining", value} -> value
+        _ -> nil
+      end)
+
+    case remaining do
+      nil ->
+        :ok
+
+      value ->
+        case Integer.parse(to_string(value)) do
+          {n, _} when n <= @rate_limit_warning_threshold ->
+            Logger.warning("GitHub API rate limit low: #{n} requests remaining")
+
+          _ ->
+            :ok
+        end
+    end
+  end
+
+  defp check_rate_limit(_), do: :ok
+
+  defp github_error_context(%{body: body}) do
+    " body=" <> summarize_error_body(body)
+  end
+
+  defp github_error_context(_), do: ""
+
+  defp summarize_error_body(body) when is_binary(body) do
+    body
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    |> truncate_error_body()
+    |> inspect()
+  end
+
+  defp summarize_error_body(body) do
+    body
+    |> inspect(limit: 20, printable_limit: @max_error_body_log_bytes)
+    |> truncate_error_body()
+  end
+
+  defp truncate_error_body(body) when is_binary(body) do
+    if byte_size(body) > @max_error_body_log_bytes do
+      binary_part(body, 0, @max_error_body_log_bytes) <> "...<truncated>"
+    else
+      body
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -415,8 +415,6 @@ defmodule SymphonyElixir.Github.Client do
     end
   end
 
-  defp check_rate_limit(_), do: :ok
-
   defp github_error_context(%{body: body}) do
     " body=" <> summarize_error_body(body)
   end

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -169,16 +169,8 @@ defmodule SymphonyElixir.Github.Client do
     results =
       Enum.reduce_while(labels, {:ok, %{}}, fn label, {:ok, acc} ->
         case fetch_all_pages(tracker, [label], tracker.assignee) do
-          {:ok, issues} ->
-            merged =
-              Enum.reduce(issues, acc, fn issue, map ->
-                Map.put_new(map, issue.id, issue)
-              end)
-
-            {:cont, {:ok, merged}}
-
-          {:error, reason} ->
-            {:halt, {:error, reason}}
+          {:ok, issues} -> {:cont, {:ok, merge_issues(issues, acc)}}
+          {:error, reason} -> {:halt, {:error, reason}}
         end
       end)
 
@@ -186,6 +178,10 @@ defmodule SymphonyElixir.Github.Client do
       {:ok, issues_map} -> {:ok, Map.values(issues_map)}
       error -> error
     end
+  end
+
+  defp merge_issues(issues, acc) do
+    Enum.reduce(issues, acc, fn issue, map -> Map.put_new(map, issue.id, issue) end)
   end
 
   defp fetch_issues_by_numbers(tracker, issue_numbers) do
@@ -288,24 +284,24 @@ defmodule SymphonyElixir.Github.Client do
     end)
   end
 
+  @state_name_to_label_map %{
+    "todo" => "todo",
+    "in progress" => "in-progress",
+    "human review" => "human-review"
+  }
+
+  @terminal_states MapSet.new(["done", "closed", "cancelled", "canceled"])
+
   @doc false
   @spec state_name_to_label(String.t(), String.t()) :: String.t() | nil
   def state_name_to_label(state_name, labels_prefix) do
-    base =
-      case String.downcase(String.trim(state_name)) do
-        "todo" -> "todo"
-        "in progress" -> "in-progress"
-        "human review" -> "human-review"
-        "done" -> nil
-        "closed" -> nil
-        "cancelled" -> nil
-        "canceled" -> nil
-        other -> other
-      end
+    normalized = String.downcase(String.trim(state_name))
 
-    case base do
-      nil -> nil
-      label -> labels_prefix <> label
+    if MapSet.member?(@terminal_states, normalized) do
+      nil
+    else
+      base = Map.get(@state_name_to_label_map, normalized, normalized)
+      labels_prefix <> base
     end
   end
 

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -40,6 +40,7 @@ defmodule SymphonyElixir.Tracker do
   def adapter do
     case Config.settings!().tracker.kind do
       "memory" -> SymphonyElixir.Tracker.Memory
+      "github" -> SymphonyElixir.Github.Adapter
       _ -> SymphonyElixir.Linear.Adapter
     end
   end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -15,6 +15,7 @@ defmodule SymphonyElixir.MixProject do
         ignore_modules: [
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
+          SymphonyElixir.Github.Client,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -99,6 +99,8 @@ defmodule SymphonyElixir.TestSupport do
           tracker_assignee: nil,
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
+          tracker_repo: nil,
+          tracker_labels_prefix: nil,
           poll_interval_ms: 30_000,
           workspace_root: Path.join(System.tmp_dir!(), "symphony_workspaces"),
           worker_ssh_hosts: [],
@@ -136,6 +138,8 @@ defmodule SymphonyElixir.TestSupport do
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
+    tracker_repo = Keyword.get(config, :tracker_repo)
+    tracker_labels_prefix = Keyword.get(config, :tracker_labels_prefix)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
     workspace_root = Keyword.get(config, :workspace_root)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
@@ -174,6 +178,8 @@ defmodule SymphonyElixir.TestSupport do
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
+        tracker_repo && "  repo: #{yaml_value(tracker_repo)}",
+        tracker_labels_prefix && "  labels_prefix: #{yaml_value(tracker_labels_prefix)}",
         "polling:",
         "  interval_ms: #{yaml_value(poll_interval_ms)}",
         "workspace:",

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -203,6 +203,9 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "linear")
     assert SymphonyElixir.Tracker.adapter() == Adapter
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "github")
+    assert SymphonyElixir.Tracker.adapter() == SymphonyElixir.Github.Adapter
   end
 
   test "linear adapter delegates reads and validates mutation responses" do

--- a/elixir/test/symphony_elixir/github/adapter_test.exs
+++ b/elixir/test/symphony_elixir/github/adapter_test.exs
@@ -1,0 +1,133 @@
+defmodule SymphonyElixir.Github.AdapterTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Github.Adapter
+  alias SymphonyElixir.Linear.Issue
+
+  defmodule MockGithubClient do
+    alias SymphonyElixir.Linear.Issue
+
+    def fetch_candidate_issues do
+      send(self(), :mock_fetch_candidate_issues)
+      {:ok, [%Issue{id: "1", identifier: "#1", title: "Test issue", state: "Todo", labels: ["todo"]}]}
+    end
+
+    def fetch_issues_by_states(states) do
+      send(self(), {:mock_fetch_issues_by_states, states})
+      {:ok, [%Issue{id: "1", identifier: "#1", title: "Test issue", state: "Todo", labels: ["todo"]}]}
+    end
+
+    def fetch_issue_states_by_ids(ids) do
+      send(self(), {:mock_fetch_issue_states_by_ids, ids})
+      {:ok, [%Issue{id: "1", identifier: "#1", title: "Test issue", state: "Todo", labels: ["todo"]}]}
+    end
+
+    def create_comment(issue_id, body) do
+      send(self(), {:mock_create_comment, issue_id, body})
+      :ok
+    end
+
+    def update_issue_state(issue_id, state_name) do
+      send(self(), {:mock_update_issue_state, issue_id, state_name})
+      :ok
+    end
+
+    def add_labels(issue_number, labels) do
+      send(self(), {:mock_add_labels, issue_number, labels})
+      :ok
+    end
+
+    def remove_label(issue_number, label) do
+      send(self(), {:mock_remove_label, issue_number, label})
+      :ok
+    end
+
+    def update_issue(issue_number, attrs) do
+      send(self(), {:mock_update_issue, issue_number, attrs})
+      :ok
+    end
+  end
+
+  setup do
+    Application.put_env(:symphony_elixir, :github_client_module, MockGithubClient)
+
+    workflow_root =
+      Path.join(System.tmp_dir!(), "symphony-github-adapter-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workflow_root)
+    workflow_file = Path.join(workflow_root, "WORKFLOW.md")
+
+    write_workflow_file!(workflow_file,
+      tracker_kind: "github",
+      tracker_api_token: "ghp_test",
+      tracker_project_slug: nil,
+      tracker_repo: "owner/repo"
+    )
+
+    SymphonyElixir.Workflow.set_workflow_file_path(workflow_file)
+    if Process.whereis(SymphonyElixir.WorkflowStore), do: SymphonyElixir.WorkflowStore.force_reload()
+
+    on_exit(fn ->
+      Application.delete_env(:symphony_elixir, :github_client_module)
+      File.rm_rf(workflow_root)
+    end)
+
+    :ok
+  end
+
+  describe "fetch_candidate_issues/0" do
+    test "delegates to client" do
+      assert {:ok, [%Issue{id: "1"}]} = Adapter.fetch_candidate_issues()
+      assert_received :mock_fetch_candidate_issues
+    end
+  end
+
+  describe "fetch_issues_by_states/1" do
+    test "delegates to client" do
+      assert {:ok, [%Issue{id: "1"}]} = Adapter.fetch_issues_by_states(["Todo"])
+      assert_received {:mock_fetch_issues_by_states, ["Todo"]}
+    end
+  end
+
+  describe "fetch_issue_states_by_ids/1" do
+    test "delegates to client" do
+      assert {:ok, [%Issue{id: "1"}]} = Adapter.fetch_issue_states_by_ids(["1"])
+      assert_received {:mock_fetch_issue_states_by_ids, ["1"]}
+    end
+  end
+
+  describe "create_comment/2" do
+    test "delegates to client" do
+      assert :ok = Adapter.create_comment("1", "Hello")
+      assert_received {:mock_create_comment, "1", "Hello"}
+    end
+  end
+
+  describe "update_issue_state/2" do
+    test "closes issue when transitioning to Done" do
+      assert :ok = Adapter.update_issue_state("1", "Done")
+      assert_received {:mock_fetch_issue_states_by_ids, ["1"]}
+      assert_received {:mock_remove_label, "1", "todo"}
+      assert_received {:mock_update_issue, "1", %{state: "closed"}}
+    end
+
+    test "closes issue when transitioning to Closed" do
+      assert :ok = Adapter.update_issue_state("1", "Closed")
+      assert_received {:mock_update_issue, "1", %{state: "closed"}}
+    end
+
+    test "swaps labels when transitioning to In Progress" do
+      assert :ok = Adapter.update_issue_state("1", "In Progress")
+      assert_received {:mock_fetch_issue_states_by_ids, ["1"]}
+      assert_received {:mock_remove_label, "1", "todo"}
+      assert_received {:mock_update_issue, "1", %{state: "open"}}
+      assert_received {:mock_add_labels, "1", ["in-progress"]}
+    end
+
+    test "swaps labels when transitioning to Human Review" do
+      assert :ok = Adapter.update_issue_state("1", "Human Review")
+      assert_received {:mock_remove_label, "1", "todo"}
+      assert_received {:mock_add_labels, "1", ["human-review"]}
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/github/adapter_test.exs
+++ b/elixir/test/symphony_elixir/github/adapter_test.exs
@@ -48,6 +48,25 @@ defmodule SymphonyElixir.Github.AdapterTest do
     end
   end
 
+  defmodule MockGithubClientWithErrors do
+    alias SymphonyElixir.Linear.Issue
+
+    def fetch_issue_states_by_ids(_ids) do
+      {:ok, [%Issue{id: "1", identifier: "#1", state: "Todo", labels: ["todo"]}]}
+    end
+
+    def remove_label(_issue_number, _label), do: {:error, :remove_failed}
+    def update_issue(_issue_number, _attrs), do: :ok
+    def add_labels(_issue_number, _labels), do: :ok
+  end
+
+  defmodule MockGithubClientFetchError do
+    def fetch_issue_states_by_ids(_ids), do: {:error, :not_found}
+    def remove_label(_issue_number, _label), do: :ok
+    def update_issue(_issue_number, _attrs), do: :ok
+    def add_labels(_issue_number, _labels), do: :ok
+  end
+
   setup do
     Application.put_env(:symphony_elixir, :github_client_module, MockGithubClient)
 
@@ -128,6 +147,27 @@ defmodule SymphonyElixir.Github.AdapterTest do
       assert :ok = Adapter.update_issue_state("1", "Human Review")
       assert_received {:mock_remove_label, "1", "todo"}
       assert_received {:mock_add_labels, "1", ["human-review"]}
+    end
+
+    test "skips add_state_label when target state maps to nil label" do
+      # "Cancelled" maps to nil label via state_name_to_label, so no label is added
+      assert :ok = Adapter.update_issue_state("1", "Cancelled")
+      assert_received {:mock_fetch_issue_states_by_ids, ["1"]}
+      assert_received {:mock_remove_label, "1", "todo"}
+      assert_received {:mock_update_issue, "1", %{state: "open"}}
+      refute_received {:mock_add_labels, _, _}
+    end
+
+    test "returns error when remove_label fails during state transition" do
+      Application.put_env(:symphony_elixir, :github_client_module, MockGithubClientWithErrors)
+      assert {:error, :remove_failed} = Adapter.update_issue_state("1", "In Progress")
+      Application.put_env(:symphony_elixir, :github_client_module, MockGithubClient)
+    end
+
+    test "handles fetch_issue_states_by_ids returning error during state lookup" do
+      Application.put_env(:symphony_elixir, :github_client_module, MockGithubClientFetchError)
+      assert :ok = Adapter.update_issue_state("1", "In Progress")
+      Application.put_env(:symphony_elixir, :github_client_module, MockGithubClient)
     end
   end
 end

--- a/elixir/test/symphony_elixir/github/client_test.exs
+++ b/elixir/test/symphony_elixir/github/client_test.exs
@@ -37,10 +37,11 @@ defmodule SymphonyElixir.Github.ClientTest do
     agent = Agent.start_link(fn -> responses end) |> elem(1)
 
     fun = fn method, path, body ->
-      response = Agent.get_and_update(agent, fn
-        [next | rest] -> {next, rest}
-        [] -> {{:ok, %{status: 500, body: "no more responses"}}, []}
-      end)
+      response =
+        Agent.get_and_update(agent, fn
+          [next | rest] -> {next, rest}
+          [] -> {{:ok, %{status: 500, body: "no more responses"}}, []}
+        end)
 
       send(self(), {:github_api_call, method, path, body})
       response

--- a/elixir/test/symphony_elixir/github/client_test.exs
+++ b/elixir/test/symphony_elixir/github/client_test.exs
@@ -1,0 +1,361 @@
+defmodule SymphonyElixir.Github.ClientTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Github.Client
+  alias SymphonyElixir.Linear.Issue
+
+  defp github_workflow_overrides do
+    [
+      tracker_kind: "github",
+      tracker_api_token: "ghp_test_token",
+      tracker_project_slug: nil,
+      tracker_endpoint: nil,
+      tracker_repo: "owner/repo"
+    ]
+  end
+
+  defp with_github_config(_context, overrides) do
+    workflow_root =
+      Path.join(System.tmp_dir!(), "symphony-github-client-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workflow_root)
+    workflow_file = Path.join(workflow_root, "WORKFLOW.md")
+
+    base =
+      github_workflow_overrides()
+      |> Keyword.merge(overrides)
+
+    write_workflow_file!(workflow_file, base)
+    SymphonyElixir.Workflow.set_workflow_file_path(workflow_file)
+    if Process.whereis(SymphonyElixir.WorkflowStore), do: SymphonyElixir.WorkflowStore.force_reload()
+
+    on_exit(fn -> File.rm_rf(workflow_root) end)
+    :ok
+  end
+
+  defp stub_request(responses) do
+    agent = Agent.start_link(fn -> responses end) |> elem(1)
+
+    fun = fn method, path, body ->
+      response = Agent.get_and_update(agent, fn
+        [next | rest] -> {next, rest}
+        [] -> {{:ok, %{status: 500, body: "no more responses"}}, []}
+      end)
+
+      send(self(), {:github_api_call, method, path, body})
+      response
+    end
+
+    Application.put_env(:symphony_elixir, :github_request_fun, fun)
+
+    on_exit(fn ->
+      Application.delete_env(:symphony_elixir, :github_request_fun)
+      if Process.alive?(agent), do: Agent.stop(agent)
+    end)
+  end
+
+  defp sample_github_issue(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "number" => 42,
+        "title" => "Fix the widget",
+        "body" => "The widget is broken",
+        "state" => "open",
+        "html_url" => "https://github.com/owner/repo/issues/42",
+        "labels" => [%{"name" => "todo"}],
+        "assignee" => %{"login" => "testuser"},
+        "created_at" => "2026-01-15T10:00:00Z",
+        "updated_at" => "2026-01-16T12:00:00Z"
+      },
+      overrides
+    )
+  end
+
+  describe "normalize_issue/2" do
+    test "normalizes a GitHub issue to Linear.Issue struct" do
+      gh_issue = sample_github_issue()
+      result = Client.normalize_issue(gh_issue, "")
+
+      assert %Issue{} = result
+      assert result.id == "42"
+      assert result.identifier == "#42"
+      assert result.title == "Fix the widget"
+      assert result.description == "The widget is broken"
+      assert result.state == "Todo"
+      assert result.branch_name == "issue-42"
+      assert result.url == "https://github.com/owner/repo/issues/42"
+      assert result.assignee_id == "testuser"
+      assert result.labels == ["todo"]
+      assert result.priority == nil
+      assert result.blocked_by == []
+    end
+
+    test "derives In Progress state from label" do
+      gh_issue = sample_github_issue(%{"labels" => [%{"name" => "in-progress"}]})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.state == "In Progress"
+    end
+
+    test "derives Human Review state from label" do
+      gh_issue = sample_github_issue(%{"labels" => [%{"name" => "human-review"}]})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.state == "Human Review"
+    end
+
+    test "derives Done state from closed issue" do
+      gh_issue = sample_github_issue(%{"state" => "closed", "labels" => []})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.state == "Done"
+    end
+
+    test "defaults to Todo when no state label present" do
+      gh_issue = sample_github_issue(%{"labels" => [%{"name" => "bug"}]})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.state == "Todo"
+    end
+
+    test "handles labels_prefix" do
+      gh_issue = sample_github_issue(%{"labels" => [%{"name" => "opal:in-progress"}]})
+      result = Client.normalize_issue(gh_issue, "opal:")
+      assert result.state == "In Progress"
+    end
+
+    test "handles nil assignee" do
+      gh_issue = sample_github_issue(%{"assignee" => nil})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.assignee_id == nil
+    end
+
+    test "handles nil body" do
+      gh_issue = sample_github_issue(%{"body" => nil})
+      result = Client.normalize_issue(gh_issue, "")
+      assert result.description == nil
+    end
+
+    test "parses datetime fields" do
+      gh_issue = sample_github_issue()
+      result = Client.normalize_issue(gh_issue, "")
+      assert %DateTime{} = result.created_at
+      assert result.created_at.year == 2026
+      assert %DateTime{} = result.updated_at
+    end
+  end
+
+  describe "state_name_to_label/2" do
+    test "maps Todo to todo label" do
+      assert Client.state_name_to_label("Todo", "") == "todo"
+    end
+
+    test "maps In Progress to in-progress label" do
+      assert Client.state_name_to_label("In Progress", "") == "in-progress"
+    end
+
+    test "maps Human Review to human-review label" do
+      assert Client.state_name_to_label("Human Review", "") == "human-review"
+    end
+
+    test "returns nil for Done" do
+      assert Client.state_name_to_label("Done", "") == nil
+    end
+
+    test "returns nil for Closed" do
+      assert Client.state_name_to_label("Closed", "") == nil
+    end
+
+    test "applies labels_prefix" do
+      assert Client.state_name_to_label("Todo", "opal:") == "opal:todo"
+    end
+
+    test "handles case insensitivity" do
+      assert Client.state_name_to_label("TODO", "") == "todo"
+      assert Client.state_name_to_label("in progress", "") == "in-progress"
+    end
+  end
+
+  describe "fetch_candidate_issues/0" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "returns issues from GitHub API" do
+      issues = [sample_github_issue()]
+
+      # active_states ["Todo", "In Progress"] → 2 label queries (union)
+      stub_request([
+        {:ok, %{status: 200, body: issues, headers: []}},
+        {:ok, %{status: 200, body: [], headers: []}}
+      ])
+
+      assert {:ok, [%Issue{id: "42", title: "Fix the widget"}]} =
+               Client.fetch_candidate_issues()
+
+      assert_received {:github_api_call, :get, path, nil}
+      assert path =~ "/repos/"
+      assert path =~ "state=open"
+    end
+
+    test "returns error when api_key is nil" do
+      workflow_file = Path.join(System.tmp_dir!(), "WORKFLOW-#{System.unique_integer([:positive])}.md")
+
+      write_workflow_file!(workflow_file,
+        tracker_kind: "github",
+        tracker_api_token: nil,
+        tracker_project_slug: nil,
+        tracker_repo: "owner/repo"
+      )
+
+      SymphonyElixir.Workflow.set_workflow_file_path(workflow_file)
+      if Process.whereis(SymphonyElixir.WorkflowStore), do: SymphonyElixir.WorkflowStore.force_reload()
+
+      assert {:error, :missing_github_api_token} = Client.fetch_candidate_issues()
+
+      File.rm(workflow_file)
+    end
+
+    test "filters out pull requests" do
+      issues = [
+        sample_github_issue(),
+        sample_github_issue(%{"number" => 43, "pull_request" => %{"url" => "..."}})
+      ]
+
+      # active_states ["Todo", "In Progress"] → 2 label queries (union)
+      stub_request([
+        {:ok, %{status: 200, body: issues, headers: []}},
+        {:ok, %{status: 200, body: [], headers: []}}
+      ])
+
+      assert {:ok, [%Issue{id: "42"}]} = Client.fetch_candidate_issues()
+    end
+  end
+
+  describe "fetch_issues_by_states/1" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "returns empty list for empty states" do
+      assert {:ok, []} = Client.fetch_issues_by_states([])
+    end
+
+    test "fetches issues matching state labels" do
+      stub_request([
+        {:ok, %{status: 200, body: [sample_github_issue()], headers: []}}
+      ])
+
+      assert {:ok, [%Issue{id: "42"}]} = Client.fetch_issues_by_states(["Todo"])
+    end
+  end
+
+  describe "fetch_issue_states_by_ids/1" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "returns empty list for empty ids" do
+      assert {:ok, []} = Client.fetch_issue_states_by_ids([])
+    end
+
+    test "fetches individual issues by number" do
+      stub_request([
+        {:ok, %{status: 200, body: sample_github_issue(), headers: []}}
+      ])
+
+      assert {:ok, [%Issue{id: "42"}]} = Client.fetch_issue_states_by_ids(["42"])
+
+      assert_received {:github_api_call, :get, path, nil}
+      assert path =~ "/issues/42"
+    end
+
+    test "skips 404 issues" do
+      stub_request([
+        {:ok, %{status: 404, body: %{"message" => "Not Found"}, headers: []}}
+      ])
+
+      assert {:ok, []} = Client.fetch_issue_states_by_ids(["999"])
+    end
+  end
+
+  describe "create_comment/2" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "posts a comment" do
+      stub_request([
+        {:ok, %{status: 201, body: %{"id" => 1}, headers: []}}
+      ])
+
+      assert :ok = Client.create_comment("42", "Hello world")
+
+      assert_received {:github_api_call, :post, path, %{body: "Hello world"}}
+      assert path =~ "/issues/42/comments"
+    end
+
+    test "returns error on failure" do
+      stub_request([
+        {:ok, %{status: 403, body: %{"message" => "Forbidden"}, headers: []}}
+      ])
+
+      assert {:error, {:github_api_status, 403}} = Client.create_comment("42", "Hello")
+    end
+  end
+
+  describe "add_labels/2" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "adds labels to an issue" do
+      stub_request([
+        {:ok, %{status: 200, body: [], headers: []}}
+      ])
+
+      assert :ok = Client.add_labels("42", ["todo"])
+
+      assert_received {:github_api_call, :post, path, %{labels: ["todo"]}}
+      assert path =~ "/issues/42/labels"
+    end
+  end
+
+  describe "remove_label/2" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "removes a label from an issue" do
+      stub_request([
+        {:ok, %{status: 200, body: [], headers: []}}
+      ])
+
+      assert :ok = Client.remove_label("42", "todo")
+
+      assert_received {:github_api_call, :delete, path, nil}
+      assert path =~ "/issues/42/labels/todo"
+    end
+
+    test "treats 404 as success (label already removed)" do
+      stub_request([
+        {:ok, %{status: 404, body: %{}, headers: []}}
+      ])
+
+      assert :ok = Client.remove_label("42", "todo")
+    end
+  end
+
+  describe "update_issue/2" do
+    setup context do
+      with_github_config(context, tracker_kind: "github")
+    end
+
+    test "patches an issue" do
+      stub_request([
+        {:ok, %{status: 200, body: %{}, headers: []}}
+      ])
+
+      assert :ok = Client.update_issue("42", %{state: "closed"})
+
+      assert_received {:github_api_call, :patch, path, %{state: "closed"}}
+      assert path =~ "/issues/42"
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/github/e2e_test.exs
+++ b/elixir/test/symphony_elixir/github/e2e_test.exs
@@ -49,7 +49,7 @@ defmodule SymphonyElixir.Github.E2ETest do
     test "fetches open issues from GitHub" do
       assert {:ok, issues} = Adapter.fetch_candidate_issues()
       assert is_list(issues)
-      assert length(issues) >= 2
+      assert [_, _ | _] = issues
 
       issue = Enum.find(issues, &(&1.identifier == "#1"))
       assert %Issue{} = issue
@@ -68,7 +68,7 @@ defmodule SymphonyElixir.Github.E2ETest do
       assert is_list(issues)
 
       todo_issues = Enum.filter(issues, &(&1.state == "Todo"))
-      assert length(todo_issues) >= 1
+      assert [_ | _] = todo_issues
     end
 
     test "fetches issues in In Progress state" do
@@ -76,7 +76,7 @@ defmodule SymphonyElixir.Github.E2ETest do
       assert is_list(issues)
 
       in_progress = Enum.filter(issues, &(&1.state == "In Progress"))
-      assert length(in_progress) >= 1
+      assert [_ | _] = in_progress
     end
 
     test "returns empty for states with no issues" do

--- a/elixir/test/symphony_elixir/github/e2e_test.exs
+++ b/elixir/test/symphony_elixir/github/e2e_test.exs
@@ -1,0 +1,133 @@
+defmodule SymphonyElixir.Github.E2ETest do
+  @moduledoc """
+  End-to-end tests for the GitHub tracker adapter against a real GitHub repo.
+  Requires GITHUB_TOKEN env var and the test repo apexphere/opal-test-tracker.
+
+  Run with: mix test test/symphony_elixir/github/e2e_test.exs --include e2e
+  """
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Github.Adapter
+  alias SymphonyElixir.Linear.Issue
+
+  @test_repo "apexphere/opal-test-tracker"
+
+  @moduletag :e2e
+
+  setup do
+    token = System.get_env("GITHUB_TOKEN")
+
+    if is_nil(token) do
+      raise "GITHUB_TOKEN env var required for e2e tests"
+    end
+
+    workflow_root =
+      Path.join(System.tmp_dir!(), "symphony-github-e2e-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workflow_root)
+    workflow_file = Path.join(workflow_root, "WORKFLOW.md")
+
+    write_workflow_file!(workflow_file,
+      tracker_kind: "github",
+      tracker_api_token: token,
+      tracker_project_slug: nil,
+      tracker_repo: @test_repo,
+      tracker_labels_prefix: ""
+    )
+
+    SymphonyElixir.Workflow.set_workflow_file_path(workflow_file)
+    if Process.whereis(SymphonyElixir.WorkflowStore), do: SymphonyElixir.WorkflowStore.force_reload()
+
+    on_exit(fn ->
+      File.rm_rf(workflow_root)
+    end)
+
+    :ok
+  end
+
+  describe "fetch_candidate_issues/0" do
+    test "fetches open issues from GitHub" do
+      assert {:ok, issues} = Adapter.fetch_candidate_issues()
+      assert is_list(issues)
+      assert length(issues) >= 2
+
+      issue = Enum.find(issues, &(&1.identifier == "#1"))
+      assert %Issue{} = issue
+      assert issue.id == "1"
+      assert issue.title == "Add user authentication"
+      assert issue.description =~ "login/logout"
+      assert issue.state in ["Todo", "In Progress", "Human Review"]
+      assert issue.url =~ "github.com"
+      assert issue.branch_name == "issue-1"
+    end
+  end
+
+  describe "fetch_issues_by_states/1" do
+    test "fetches issues in Todo state" do
+      assert {:ok, issues} = Adapter.fetch_issues_by_states(["Todo"])
+      assert is_list(issues)
+
+      todo_issues = Enum.filter(issues, &(&1.state == "Todo"))
+      assert length(todo_issues) >= 1
+    end
+
+    test "fetches issues in In Progress state" do
+      assert {:ok, issues} = Adapter.fetch_issues_by_states(["In Progress"])
+      assert is_list(issues)
+
+      in_progress = Enum.filter(issues, &(&1.state == "In Progress"))
+      assert length(in_progress) >= 1
+    end
+
+    test "returns empty for states with no issues" do
+      assert {:ok, issues} = Adapter.fetch_issues_by_states(["Human Review"])
+      human_review = Enum.filter(issues, &(&1.state == "Human Review"))
+      assert human_review == []
+    end
+  end
+
+  describe "fetch_issue_states_by_ids/1" do
+    test "fetches specific issues by number" do
+      assert {:ok, issues} = Adapter.fetch_issue_states_by_ids(["1", "2"])
+      assert length(issues) == 2
+
+      ids = Enum.map(issues, & &1.id)
+      assert "1" in ids
+      assert "2" in ids
+    end
+
+    test "skips nonexistent issues" do
+      assert {:ok, issues} = Adapter.fetch_issue_states_by_ids(["99999"])
+      assert issues == []
+    end
+  end
+
+  describe "create_comment/2" do
+    test "posts a comment on an issue" do
+      comment_body = "E2E test comment at #{DateTime.utc_now() |> DateTime.to_iso8601()}"
+      assert :ok = Adapter.create_comment("1", comment_body)
+    end
+  end
+
+  describe "update_issue_state/2" do
+    test "transitions issue from Todo to In Progress and back" do
+      # Issue #3 starts as Todo
+      assert {:ok, [issue]} = Adapter.fetch_issue_states_by_ids(["3"])
+      original_state = issue.state
+
+      # Transition to In Progress
+      assert :ok = Adapter.update_issue_state("3", "In Progress")
+      Process.sleep(1_000)
+
+      assert {:ok, [updated]} = Adapter.fetch_issue_states_by_ids(["3"])
+      assert updated.state == "In Progress"
+
+      # Transition back to original state
+      assert :ok = Adapter.update_issue_state("3", original_state)
+      Process.sleep(1_000)
+
+      assert {:ok, [restored]} = Adapter.fetch_issue_states_by_ids(["3"])
+      assert restored.state == original_state
+    end
+  end
+end

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.start()
+ExUnit.start(exclude: [:e2e])
 Code.require_file("support/snapshot_support.exs", __DIR__)
 Code.require_file("support/test_support.exs", __DIR__)


### PR DESCRIPTION
#### Context

Opal needs a GitHub Issues adapter to replace the Linear-only tracker, unblocking #2 and #3 for a fully project-agnostic orchestrator.

#### TL;DR

*Add GitHub Issues tracker adapter implementing all 5 Tracker behaviour callbacks with label-based state mapping.*

#### Summary

- New `SymphonyElixir.Github.Client` — GitHub REST API client via Req with pagination, rate-limit warnings, and issue normalization
- New `SymphonyElixir.Github.Adapter` — Tracker behaviour impl that delegates reads to Client and handles state transitions via label swaps
- Config schema extended with `repo` and `labels_prefix` fields; `finalize_settings` resolves `$GITHUB_TOKEN` when `kind: "github"`
- `Tracker.adapter/0` routes to GitHub adapter when `kind: "github"`
- State mapping: labels `todo`/`in-progress`/`human-review` → Symphony states; `Done` = close issue
- Uses label union queries (one API call per state label) because GitHub's `labels` param uses AND logic
- 38 unit tests + 8 e2e tests against `apexphere/opal-test-tracker`

#### Alternatives

- GraphQL API instead of REST — REST is simpler and sufficient for issue CRUD; GraphQL would add complexity without benefit
- Single Issue struct rename to generic `Task` — deferred to #3 (generic prompt + Docker packaging) to keep this PR focused

#### Test Plan

- [ ] `make -C elixir all`
- [ ] `mix test test/symphony_elixir/github/` — 38 unit tests pass
- [ ] `GITHUB_TOKEN=... mix test test/symphony_elixir/github/e2e_test.exs --include e2e` — 8 e2e tests pass against real GitHub API
- [ ] Existing tests unaffected (266 pass, 2 pre-existing timing flakes in CoreTest)

Closes #1