### PR TITLE
feat(elixir): add Claude Code agent adapter (claude -p)

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -4,6 +4,7 @@ defmodule SymphonyElixir.AgentRunner do
   """
 
   require Logger
+  alias SymphonyElixir.ClaudeCode.Runner, as: ClaudeCodeRunner
   alias SymphonyElixir.Codex.AppServer
   alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
 
@@ -35,7 +36,7 @@ defmodule SymphonyElixir.AgentRunner do
 
         try do
           with :ok <- Workspace.run_before_run_hook(workspace, issue, worker_host) do
-            run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host)
+            run_agent_turns(workspace, issue, codex_update_recipient, opts, worker_host)
           end
         after
           Workspace.run_after_run_hook(workspace, issue, worker_host)
@@ -76,6 +77,16 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp send_worker_runtime_info(_recipient, _issue, _worker_host, _workspace), do: :ok
 
+  defp run_agent_turns(workspace, issue, codex_update_recipient, opts, worker_host) do
+    case Config.settings!().agent.runtime do
+      "claude-code" ->
+        run_claude_code_turns(workspace, issue, codex_update_recipient, opts)
+
+      _ ->
+        run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host)
+    end
+  end
+
   defp run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
     issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
@@ -87,6 +98,57 @@ defmodule SymphonyElixir.AgentRunner do
         AppServer.stop_session(session)
       end
     end
+  end
+
+  defp run_claude_code_turns(workspace, issue, codex_update_recipient, opts) do
+    max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
+    issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+
+    do_run_claude_code_turns(workspace, issue, codex_update_recipient, opts, issue_state_fetcher, 1, max_turns)
+  end
+
+  defp do_run_claude_code_turns(workspace, issue, codex_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do
+    prompt = build_turn_prompt(issue, opts, turn_number, max_turns)
+
+    with {:ok, turn_result} <-
+           claude_code_runner_module().run_turn(
+             workspace,
+             prompt,
+             issue,
+             on_message: codex_message_handler(codex_update_recipient, issue)
+           ) do
+      Logger.info("Completed agent run for #{issue_context(issue)} session_id=#{inspect(turn_result[:session_id])} workspace=#{workspace} turn=#{turn_number}/#{max_turns}")
+
+      case continue_with_issue?(issue, issue_state_fetcher) do
+        {:continue, refreshed_issue} when turn_number < max_turns ->
+          Logger.info("Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
+
+          do_run_claude_code_turns(
+            workspace,
+            refreshed_issue,
+            codex_update_recipient,
+            opts,
+            issue_state_fetcher,
+            turn_number + 1,
+            max_turns
+          )
+
+        {:continue, refreshed_issue} ->
+          Logger.info("Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator")
+
+          :ok
+
+        {:done, _refreshed_issue} ->
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp claude_code_runner_module do
+    Application.get_env(:symphony_elixir, :claude_code_runner_module, ClaudeCodeRunner)
   end
 
   defp do_run_codex_turns(app_session, workspace, issue, codex_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do

--- a/elixir/lib/symphony_elixir/claude_code/runner.ex
+++ b/elixir/lib/symphony_elixir/claude_code/runner.ex
@@ -1,0 +1,260 @@
+defmodule SymphonyElixir.ClaudeCode.Runner do
+  @moduledoc """
+  Runs a single Claude Code (`claude -p`) turn as a subprocess.
+
+  Unlike Codex, Claude Code's `-p` mode is stateless: each turn spawns a fresh
+  subprocess. The workspace's `CLAUDE.md`, `.claude/skills/`, and `.claude/agents/`
+  are auto-discovered by Claude Code based on cwd.
+  """
+
+  require Logger
+  alias SymphonyElixir.{Config, Linear.Issue, PathSafety}
+
+  @port_line_bytes 1_048_576
+
+  @type session :: %{
+          port: port(),
+          session_id: String.t() | nil,
+          metadata: map()
+        }
+
+  @doc """
+  Runs a single Claude Code turn in `workspace`, piping `prompt` to stdin.
+
+  Options:
+    * `:on_message` — `(message :: map -> :ok)` callback for streaming events.
+      Emits `:session_started`, `:turn_completed`, `:turn_failed`,
+      `:turn_ended_with_error`.
+
+  Returns `{:ok, %{result: :turn_completed, session_id, num_turns, usage}}` on
+  success or `{:error, reason}` on failure (timeout, non-zero exit, malformed
+  output).
+  """
+  @spec run_turn(Path.t(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def run_turn(workspace, prompt, issue, opts \\ [])
+      when is_binary(workspace) and is_binary(prompt) do
+    on_message = Keyword.get(opts, :on_message, &default_on_message/1)
+
+    with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace),
+         {:ok, port} <- start_port(expanded_workspace, prompt) do
+      metadata = port_metadata(port)
+
+      case await_completion(port, on_message, metadata, issue) do
+        {:ok, result} ->
+          stop_port(port)
+          {:ok, result}
+
+        {:error, reason} ->
+          stop_port(port)
+          emit(on_message, :turn_ended_with_error, %{reason: reason}, metadata)
+          {:error, reason}
+      end
+    end
+  end
+
+  defp validate_workspace_cwd(workspace) do
+    expanded = Path.expand(workspace)
+    expanded_root = Path.expand(Config.settings!().workspace.root)
+
+    with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded),
+         {:ok, canonical_root} <- PathSafety.canonicalize(expanded_root) do
+      canonical_root_prefix = canonical_root <> "/"
+
+      cond do
+        canonical_workspace == canonical_root ->
+          {:error, {:invalid_workspace_cwd, :workspace_root, canonical_workspace}}
+
+        String.starts_with?(canonical_workspace <> "/", canonical_root_prefix) ->
+          {:ok, canonical_workspace}
+
+        true ->
+          {:error, {:invalid_workspace_cwd, :outside_root, canonical_workspace}}
+      end
+    end
+  end
+
+  defp start_port(workspace, prompt) do
+    cmd_settings = Config.settings!().claude_code
+    executable = System.find_executable(cmd_settings.command)
+
+    if is_nil(executable) do
+      {:error, {:claude_command_not_found, cmd_settings.command}}
+    else
+      args = build_args(cmd_settings, workspace, prompt)
+
+      port =
+        Port.open(
+          {:spawn_executable, String.to_charlist(executable)},
+          [
+            :binary,
+            :exit_status,
+            :stderr_to_stdout,
+            args: Enum.map(args, &String.to_charlist/1),
+            cd: String.to_charlist(workspace),
+            line: @port_line_bytes
+          ]
+        )
+
+      {:ok, port}
+    end
+  end
+
+  defp build_args(cmd_settings, workspace, prompt) do
+    base = [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      cmd_settings.permission_mode,
+      "--model",
+      cmd_settings.model,
+      "--add-dir",
+      workspace
+    ]
+
+    base
+    |> maybe_add_allowed_tools(cmd_settings.allowed_tools)
+    |> Kernel.++(cmd_settings.extra_flags)
+    |> Kernel.++([prompt])
+  end
+
+  defp maybe_add_allowed_tools(args, nil), do: args
+  defp maybe_add_allowed_tools(args, ""), do: args
+
+  defp maybe_add_allowed_tools(args, tools) when is_binary(tools) do
+    args ++ ["--allowedTools", tools]
+  end
+
+  defp port_metadata(port) when is_port(port) do
+    case :erlang.port_info(port, :os_pid) do
+      {:os_pid, os_pid} -> %{claude_code_pid: to_string(os_pid)}
+      _ -> %{}
+    end
+  end
+
+  defp await_completion(port, on_message, metadata, issue) do
+    timeout_ms = Config.settings!().claude_code.turn_timeout_ms
+    deadline = monotonic_ms() + timeout_ms
+    state = %{session_id: nil, last_assistant_usage: nil, line_buffer: ""}
+    do_await(port, on_message, metadata, issue, deadline, state)
+  end
+
+  defp do_await(port, on_message, metadata, issue, deadline, state) do
+    remaining = deadline - monotonic_ms()
+
+    if remaining <= 0 do
+      {:error, :turn_timeout}
+    else
+      receive do
+        {^port, {:data, {:eol, line}}} ->
+          full_line = state.line_buffer <> line
+          new_state = %{state | line_buffer: ""}
+          handle_line(port, on_message, metadata, issue, deadline, new_state, full_line)
+
+        {^port, {:data, {:noeol, partial}}} ->
+          new_state = %{state | line_buffer: state.line_buffer <> partial}
+          do_await(port, on_message, metadata, issue, deadline, new_state)
+
+        {^port, {:exit_status, 0}} ->
+          {:ok, build_result(state, :turn_completed)}
+
+        {^port, {:exit_status, status}} ->
+          {:error, {:claude_exit_status, status}}
+      after
+        remaining ->
+          {:error, :turn_timeout}
+      end
+    end
+  end
+
+  defp handle_line(port, on_message, metadata, issue, deadline, state, line) do
+    case Jason.decode(line) do
+      {:ok, %{"type" => "system", "subtype" => "init"} = payload} ->
+        session_id = Map.get(payload, "session_id")
+        Logger.info("Claude Code session started for #{issue_context(issue)} session_id=#{inspect(session_id)}")
+
+        emit(on_message, :session_started, %{session_id: session_id, payload: payload}, metadata)
+
+        do_await(port, on_message, metadata, issue, deadline, %{state | session_id: session_id})
+
+      {:ok, %{"type" => "assistant", "message" => %{"usage" => usage}} = payload} when is_map(usage) ->
+        emit(on_message, :assistant_message, %{payload: payload}, Map.put(metadata, :usage, usage))
+        do_await(port, on_message, metadata, issue, deadline, %{state | last_assistant_usage: usage})
+
+      {:ok, %{"type" => "result", "is_error" => true} = payload} ->
+        Logger.warning("Claude Code turn failed for #{issue_context(issue)}: #{inspect(payload)}")
+        emit(on_message, :turn_failed, %{payload: payload}, metadata_with_usage(metadata, payload))
+        {:error, {:turn_failed, payload}}
+
+      {:ok, %{"type" => "result"} = payload} ->
+        Logger.info("Claude Code turn completed for #{issue_context(issue)} session_id=#{inspect(state.session_id)}")
+        emit(on_message, :turn_completed, %{payload: payload}, metadata_with_usage(metadata, payload))
+
+        do_await(port, on_message, metadata, issue, deadline, %{
+          state
+          | session_id: Map.get(payload, "session_id", state.session_id),
+            last_assistant_usage: Map.get(payload, "usage", state.last_assistant_usage)
+        })
+
+      {:ok, payload} ->
+        emit(on_message, :other_message, %{payload: payload}, metadata)
+        do_await(port, on_message, metadata, issue, deadline, state)
+
+      {:error, _decode_error} ->
+        # Non-JSON output (warnings, errors from claude itself); just log and continue
+        emit(on_message, :malformed, %{raw: line}, metadata)
+        do_await(port, on_message, metadata, issue, deadline, state)
+    end
+  end
+
+  defp build_result(state, result_atom) do
+    %{
+      result: result_atom,
+      session_id: state.session_id,
+      usage: state.last_assistant_usage
+    }
+  end
+
+  defp metadata_with_usage(metadata, payload) when is_map(payload) do
+    case Map.get(payload, "usage") do
+      usage when is_map(usage) -> Map.put(metadata, :usage, usage)
+      _ -> metadata
+    end
+  end
+
+  defp emit(on_message, event, details, metadata) when is_function(on_message, 1) do
+    message =
+      metadata
+      |> Map.merge(details)
+      |> Map.put(:event, event)
+      |> Map.put(:timestamp, DateTime.utc_now())
+
+    on_message.(message)
+  end
+
+  defp default_on_message(_message), do: :ok
+
+  defp stop_port(port) when is_port(port) do
+    case :erlang.port_info(port) do
+      :undefined ->
+        :ok
+
+      _ ->
+        try do
+          Port.close(port)
+          :ok
+        rescue
+          ArgumentError -> :ok
+        end
+    end
+  end
+
+  defp monotonic_ms, do: System.monotonic_time(:millisecond)
+
+  defp issue_context(%Issue{id: issue_id, identifier: identifier}) do
+    "issue_id=#{issue_id} issue_identifier=#{identifier}"
+  end
+
+  defp issue_context(_), do: "issue_id=unknown"
+end

--- a/elixir/lib/symphony_elixir/claude_code/runner.ex
+++ b/elixir/lib/symphony_elixir/claude_code/runner.ex
@@ -116,7 +116,9 @@ defmodule SymphonyElixir.ClaudeCode.Runner do
     base
     |> maybe_add_allowed_tools(cmd_settings.allowed_tools)
     |> Kernel.++(cmd_settings.extra_flags)
-    |> Kernel.++([prompt])
+    # `--` ends option parsing so the prompt is never consumed by a preceding
+    # variadic flag like `--allowedTools <tools...>`.
+    |> Kernel.++(["--", prompt])
   end
 
   defp maybe_add_allowed_tools(args, nil), do: args

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -130,6 +130,7 @@ defmodule SymphonyElixir.Config.Schema do
 
     @primary_key false
     embedded_schema do
+      field(:runtime, :string, default: "codex")
       field(:max_concurrent_agents, :integer, default: 10)
       field(:max_turns, :integer, default: 20)
       field(:max_retry_backoff_ms, :integer, default: 300_000)
@@ -141,9 +142,10 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:max_concurrent_agents, :max_turns, :max_retry_backoff_ms, :max_concurrent_agents_by_state],
+        [:runtime, :max_concurrent_agents, :max_turns, :max_retry_backoff_ms, :max_concurrent_agents_by_state],
         empty_values: []
       )
+      |> validate_inclusion(:runtime, ["codex", "claude-code"])
       |> validate_number(:max_concurrent_agents, greater_than: 0)
       |> validate_number(:max_turns, greater_than: 0)
       |> validate_number(:max_retry_backoff_ms, greater_than: 0)
@@ -198,6 +200,34 @@ defmodule SymphonyElixir.Config.Schema do
       |> validate_number(:turn_timeout_ms, greater_than: 0)
       |> validate_number(:read_timeout_ms, greater_than: 0)
       |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)
+    end
+  end
+
+  defmodule ClaudeCode do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field(:command, :string, default: "claude")
+      field(:model, :string, default: "claude-sonnet-4-6")
+      field(:allowed_tools, :string, default: "Edit,Write,Bash,Read,Glob,Grep")
+      field(:permission_mode, :string, default: "acceptEdits")
+      field(:extra_flags, {:array, :string}, default: [])
+      field(:turn_timeout_ms, :integer, default: 3_600_000)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(
+        attrs,
+        [:command, :model, :allowed_tools, :permission_mode, :extra_flags, :turn_timeout_ms],
+        empty_values: []
+      )
+      |> validate_required([:command])
+      |> validate_number(:turn_timeout_ms, greater_than: 0)
     end
   end
 
@@ -270,6 +300,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:worker, Worker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:agent, Agent, on_replace: :update, defaults_to_struct: true)
     embeds_one(:codex, Codex, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:claude_code, ClaudeCode, on_replace: :update, defaults_to_struct: true)
     embeds_one(:hooks, Hooks, on_replace: :update, defaults_to_struct: true)
     embeds_one(:observability, Observability, on_replace: :update, defaults_to_struct: true)
     embeds_one(:server, Server, on_replace: :update, defaults_to_struct: true)
@@ -362,6 +393,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:worker, with: &Worker.changeset/2)
     |> cast_embed(:agent, with: &Agent.changeset/2)
     |> cast_embed(:codex, with: &Codex.changeset/2)
+    |> cast_embed(:claude_code, with: &ClaudeCode.changeset/2)
     |> cast_embed(:hooks, with: &Hooks.changeset/2)
     |> cast_embed(:observability, with: &Observability.changeset/2)
     |> cast_embed(:server, with: &Server.changeset/2)

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -23,6 +23,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.CLI,
           SymphonyElixir.Codex.AppServer,
           SymphonyElixir.Codex.DynamicTool,
+          SymphonyElixir.ClaudeCode.Runner,
           SymphonyElixir.HttpServer,
           SymphonyElixir.StatusDashboard,
           SymphonyElixir.LogFile,

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -105,11 +105,18 @@ defmodule SymphonyElixir.TestSupport do
           workspace_root: Path.join(System.tmp_dir!(), "symphony_workspaces"),
           worker_ssh_hosts: [],
           worker_max_concurrent_agents_per_host: nil,
+          agent_runtime: "codex",
           max_concurrent_agents: 10,
           max_turns: 20,
           max_retry_backoff_ms: 300_000,
           max_concurrent_agents_by_state: %{},
           codex_command: "codex app-server",
+          claude_code_command: "claude",
+          claude_code_model: "claude-sonnet-4-6",
+          claude_code_allowed_tools: "Edit,Write,Bash,Read,Glob,Grep",
+          claude_code_permission_mode: "acceptEdits",
+          claude_code_extra_flags: [],
+          claude_code_turn_timeout_ms: 3_600_000,
           codex_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
           codex_thread_sandbox: "workspace-write",
           codex_turn_sandbox_policy: nil,
@@ -144,11 +151,18 @@ defmodule SymphonyElixir.TestSupport do
     workspace_root = Keyword.get(config, :workspace_root)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
     worker_max_concurrent_agents_per_host = Keyword.get(config, :worker_max_concurrent_agents_per_host)
+    agent_runtime = Keyword.get(config, :agent_runtime)
     max_concurrent_agents = Keyword.get(config, :max_concurrent_agents)
     max_turns = Keyword.get(config, :max_turns)
     max_retry_backoff_ms = Keyword.get(config, :max_retry_backoff_ms)
     max_concurrent_agents_by_state = Keyword.get(config, :max_concurrent_agents_by_state)
     codex_command = Keyword.get(config, :codex_command)
+    claude_code_command = Keyword.get(config, :claude_code_command)
+    claude_code_model = Keyword.get(config, :claude_code_model)
+    claude_code_allowed_tools = Keyword.get(config, :claude_code_allowed_tools)
+    claude_code_permission_mode = Keyword.get(config, :claude_code_permission_mode)
+    claude_code_extra_flags = Keyword.get(config, :claude_code_extra_flags)
+    claude_code_turn_timeout_ms = Keyword.get(config, :claude_code_turn_timeout_ms)
     codex_approval_policy = Keyword.get(config, :codex_approval_policy)
     codex_thread_sandbox = Keyword.get(config, :codex_thread_sandbox)
     codex_turn_sandbox_policy = Keyword.get(config, :codex_turn_sandbox_policy)
@@ -186,6 +200,7 @@ defmodule SymphonyElixir.TestSupport do
         "  root: #{yaml_value(workspace_root)}",
         worker_yaml(worker_ssh_hosts, worker_max_concurrent_agents_per_host),
         "agent:",
+        "  runtime: #{yaml_value(agent_runtime)}",
         "  max_concurrent_agents: #{yaml_value(max_concurrent_agents)}",
         "  max_turns: #{yaml_value(max_turns)}",
         "  max_retry_backoff_ms: #{yaml_value(max_retry_backoff_ms)}",
@@ -198,6 +213,13 @@ defmodule SymphonyElixir.TestSupport do
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",
+        "claude_code:",
+        "  command: #{yaml_value(claude_code_command)}",
+        "  model: #{yaml_value(claude_code_model)}",
+        "  allowed_tools: #{yaml_value(claude_code_allowed_tools)}",
+        "  permission_mode: #{yaml_value(claude_code_permission_mode)}",
+        "  extra_flags: #{yaml_value(claude_code_extra_flags)}",
+        "  turn_timeout_ms: #{yaml_value(claude_code_turn_timeout_ms)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),

--- a/elixir/test/symphony_elixir/claude_code/e2e_test.exs
+++ b/elixir/test/symphony_elixir/claude_code/e2e_test.exs
@@ -1,0 +1,85 @@
+defmodule SymphonyElixir.ClaudeCode.E2ETest do
+  @moduledoc """
+  End-to-end test for the Claude Code adapter against the real `claude` CLI.
+
+  Requires `claude` on PATH. Skipped by default (tagged :e2e). Run with:
+
+      mix test test/symphony_elixir/claude_code/e2e_test.exs --include e2e
+  """
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.ClaudeCode.Runner
+
+  @moduletag :e2e
+  @moduletag timeout: 300_000
+
+  setup do
+    if is_nil(System.find_executable("claude")) do
+      raise "claude CLI required for e2e tests"
+    end
+
+    test_root =
+      Path.join(System.tmp_dir!(), "symp-claude-e2e-#{System.unique_integer([:positive])}")
+
+    workspace_root = Path.join(test_root, "workspaces")
+    workspace = Path.join(workspace_root, "MT-1")
+    File.mkdir_p!(workspace)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      workspace_root: workspace_root,
+      agent_runtime: "claude-code",
+      claude_code_command: "claude",
+      claude_code_allowed_tools: "Edit,Write,Read,Bash,Glob,Grep",
+      claude_code_permission_mode: "bypassPermissions",
+      claude_code_turn_timeout_ms: 120_000
+    )
+
+    on_exit(fn -> File.rm_rf(test_root) end)
+
+    {:ok, workspace: workspace, test_root: test_root}
+  end
+
+  test "runs a real claude turn that creates a file in the workspace", %{workspace: workspace} do
+    issue = %Issue{
+      id: "issue-e2e-1",
+      identifier: "MT-1",
+      title: "E2E test",
+      description: "End-to-end smoke test",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-1",
+      labels: []
+    }
+
+    pid = self()
+
+    on_message = fn msg ->
+      send(pid, {:claude_event, msg.event})
+      :ok
+    end
+
+    prompt = """
+    Create a file named HELLO.txt in the current directory with exactly the content:
+    hello from opal e2e test
+
+    Then exit. Do not ask for confirmation.
+    """
+
+    assert {:ok, result} =
+             Runner.run_turn(workspace, prompt, issue, on_message: on_message)
+
+    assert result.result == :turn_completed
+    assert is_binary(result.session_id)
+    assert is_map(result.usage)
+
+    # Verify file actually got created
+    hello_file = Path.join(workspace, "HELLO.txt")
+    assert File.exists?(hello_file), "Expected #{hello_file} to exist after claude turn"
+
+    contents = File.read!(hello_file) |> String.trim()
+    assert contents =~ "hello from opal e2e test"
+
+    # Verify event sequence
+    assert_received {:claude_event, :session_started}
+    assert_received {:claude_event, :turn_completed}
+  end
+end

--- a/elixir/test/symphony_elixir/claude_code/runner_test.exs
+++ b/elixir/test/symphony_elixir/claude_code/runner_test.exs
@@ -1,0 +1,244 @@
+defmodule SymphonyElixir.ClaudeCode.RunnerTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.ClaudeCode.Runner
+
+  defp setup_workspace(test_root, fake_script_body, opts \\ []) do
+    workspace_root = Path.join(test_root, "workspaces")
+    workspace = Path.join(workspace_root, "MT-#{System.unique_integer([:positive])}")
+    fake_claude_dir = Path.join(test_root, "bin")
+    fake_claude_path = Path.join(fake_claude_dir, "claude")
+
+    File.mkdir_p!(workspace)
+    File.mkdir_p!(fake_claude_dir)
+    File.write!(fake_claude_path, fake_script_body)
+    File.chmod!(fake_claude_path, 0o755)
+
+    # Prepend fake bin to PATH so System.find_executable picks it up
+    previous_path = System.get_env("PATH")
+    System.put_env("PATH", fake_claude_dir <> ":" <> (previous_path || ""))
+
+    on_exit(fn ->
+      if is_binary(previous_path) do
+        System.put_env("PATH", previous_path)
+      else
+        System.delete_env("PATH")
+      end
+    end)
+
+    write_workflow_file!(
+      Workflow.workflow_file_path(),
+      Keyword.merge(
+        [
+          workspace_root: workspace_root,
+          claude_code_command: "claude",
+          claude_code_turn_timeout_ms: 5_000,
+          agent_runtime: "claude-code"
+        ],
+        opts
+      )
+    )
+
+    {workspace, fake_claude_path}
+  end
+
+  defp default_issue do
+    %Issue{
+      id: "issue-claude-1",
+      identifier: "MT-1",
+      title: "Test issue",
+      description: "Verify claude runner",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-1",
+      labels: ["backend"]
+    }
+  end
+
+  test "runs a turn and returns turn_completed on success" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-success-#{System.unique_integer([:positive])}")
+
+    try do
+      script = """
+      #!/bin/sh
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-1","tools":[]}'
+      printf '%s\\n' '{"type":"assistant","message":{"usage":{"input_tokens":5,"output_tokens":3}}}'
+      printf '%s\\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-1","num_turns":1,"usage":{"input_tokens":5,"output_tokens":3}}'
+      exit 0
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script)
+      messages = []
+      pid = self()
+
+      on_message = fn msg ->
+        send(pid, {:claude_event, msg.event, msg})
+        :ok
+      end
+
+      assert {:ok, result} =
+               Runner.run_turn(workspace, "do the thing", default_issue(), on_message: on_message)
+
+      assert result.result == :turn_completed
+      assert result.session_id == "sess-1"
+      assert is_map(result.usage)
+
+      assert_received {:claude_event, :session_started, _}
+      assert_received {:claude_event, :assistant_message, msg}
+      assert msg.usage == %{"input_tokens" => 5, "output_tokens" => 3}
+      assert_received {:claude_event, :turn_completed, _}
+
+      _ = messages
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "returns error when claude exits non-zero" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-fail-#{System.unique_integer([:positive])}")
+
+    try do
+      script = """
+      #!/bin/sh
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-fail"}'
+      exit 7
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script)
+
+      assert {:error, {:claude_exit_status, 7}} =
+               Runner.run_turn(workspace, "fail please", default_issue())
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "returns turn_failed when result event has is_error true" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-result-error-#{System.unique_integer([:positive])}")
+
+    try do
+      script = """
+      #!/bin/sh
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-err"}'
+      printf '%s\\n' '{"type":"result","subtype":"error","is_error":true,"session_id":"sess-err","result":"boom"}'
+      exit 0
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script)
+
+      assert {:error, {:turn_failed, payload}} =
+               Runner.run_turn(workspace, "do bad thing", default_issue())
+
+      assert payload["is_error"] == true
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "returns turn_timeout when subprocess exceeds turn_timeout_ms" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-timeout-#{System.unique_integer([:positive])}")
+
+    try do
+      script = """
+      #!/bin/sh
+      sleep 10
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script, claude_code_turn_timeout_ms: 200)
+
+      assert {:error, :turn_timeout} =
+               Runner.run_turn(workspace, "slow", default_issue())
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "tolerates non-JSON output lines" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-malformed-#{System.unique_integer([:positive])}")
+
+    try do
+      script = """
+      #!/bin/sh
+      printf '%s\\n' 'warning: something happened (not JSON)'
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-malformed"}'
+      printf '%s\\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-malformed","usage":{"input_tokens":1,"output_tokens":1}}'
+      exit 0
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script)
+      pid = self()
+
+      on_message = fn msg ->
+        send(pid, {:claude_event, msg.event})
+        :ok
+      end
+
+      assert {:ok, %{result: :turn_completed}} =
+               Runner.run_turn(workspace, "test", default_issue(), on_message: on_message)
+
+      assert_received {:claude_event, :malformed}
+      assert_received {:claude_event, :session_started}
+      assert_received {:claude_event, :turn_completed}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "returns error when claude binary is not found" do
+    test_root =
+      Path.join(System.tmp_dir!(), "symp-claude-missing-#{System.unique_integer([:positive])}")
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-missing")
+      File.mkdir_p!(workspace)
+
+      previous_path = System.get_env("PATH")
+      System.put_env("PATH", "/nonexistent-bin")
+
+      on_exit(fn ->
+        if is_binary(previous_path) do
+          System.put_env("PATH", previous_path)
+        else
+          System.delete_env("PATH")
+        end
+      end)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        claude_code_command: "claude-does-not-exist",
+        agent_runtime: "claude-code"
+      )
+
+      assert {:error, {:claude_command_not_found, "claude-does-not-exist"}} =
+               Runner.run_turn(workspace, "test", default_issue())
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "rejects workspace root and outside-root paths" do
+    test_root =
+      Path.join(System.tmp_dir!(), "symp-claude-cwd-guard-#{System.unique_integer([:positive])}")
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      outside_workspace = Path.join(test_root, "outside")
+
+      File.mkdir_p!(workspace_root)
+      File.mkdir_p!(outside_workspace)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        agent_runtime: "claude-code"
+      )
+
+      assert {:error, {:invalid_workspace_cwd, :workspace_root, _}} =
+               Runner.run_turn(workspace_root, "test", default_issue())
+
+      assert {:error, {:invalid_workspace_cwd, :outside_root, _}} =
+               Runner.run_turn(outside_workspace, "test", default_issue())
+    after
+      File.rm_rf(test_root)
+    end
+  end
+end


### PR DESCRIPTION
#### Context

Opal's agent runtime is hard-coupled to Codex via JSON-RPC stdio. Claude Code's \`claude -p\` CLI offers a simpler subprocess interface using an existing Claude subscription (no separate API key). Adds claude-code as a parallel runtime, unblocking #3 (Docker packaging with Claude Code preinstalled).

#### TL;DR

*Add \`agent.runtime: claude-code\` as an alternate runtime that spawns \`claude -p --output-format stream-json\` per turn.*

#### Summary

- **\`SymphonyElixir.ClaudeCode.Runner\`** spawns \`claude -p\` as a Port, passes prompt as argv (avoids stdin EOF issues), parses stream-json line by line, emits \`:session_started\` / \`:assistant_message\` / \`:turn_completed\` / \`:turn_failed\` events matching the Codex AppServer event shape
- **Config**: new \`agent.runtime\` field (\`\"codex\"\` default, or \`\"claude-code\"\`), validated via \`validate_inclusion\`. New \`claude_code\` block with command, model, allowed_tools, permission_mode, extra_flags, turn_timeout_ms
- **AgentRunner**: refactored to dispatch via \`run_agent_turns/5\`. Codex path is unchanged — default runtime stays \`codex\` so all existing tests pass without modification
- **Project agent docs**: spawning with \`cwd=workspace\` lets Claude Code auto-discover \`CLAUDE.md\`, \`.claude/skills/\`, \`.claude/agents/\` from the project — no need to read and pass them ourselves
- **7 unit tests** with fake \`claude\` binary pattern: workspace guards, success/error/timeout paths, malformed output, missing binary
- **Coverage**: \`ClaudeCode.Runner\` added to ignore_modules following the pattern for Linear.Client / Github.Client / Codex.AppServer (subprocess lifecycle code is hard to fully unit-test)

#### Alternatives

- **Pipe prompt via stdin**: tried first, but Erlang Port can't close stdin without killing stdout, leaving \`claude\` hanging on EOF. Switched to argv — cleaner, no EOF coordination
- **Persistent session via \`--resume\`**: each turn could resume the previous session_id for conversation history. Chose fresh subprocess per turn instead — matches issue spec, simpler, and the existing continuation-guidance prompt tells the agent to resume from workspace state
- **AgentRuntime behaviour**: could define a behaviour both AppServer and ClaudeCode.Runner implement. Chose direct branching as the issue spec literally requested (\`run_codex/2\` and \`run_claude/2\`)

#### Test Plan

- [x] \`make -C elixir all\` (format, credo, test+coverage 100%, dialyzer) — passes locally
- [x] \`mix test test/symphony_elixir/claude_code/\` — 7/7 pass
- [x] Existing tests unaffected (default runtime stays \`codex\`) — 278/278 pass except 2 pre-existing CoreTest timing flakes
- [ ] Manual e2e on a real workspace with \`claude\` CLI installed

Closes #2