### PR TITLE
feat: generic project-adaptive prompt + Docker packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+# Build stage: compile the Opal escript with Elixir/OTP toolchain.
+FROM elixir:1.19-otp-28 AS build
+
+WORKDIR /app
+
+# Cache hex/rebar across builds.
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY elixir/mix.exs elixir/mix.lock ./
+RUN mix deps.get --only prod
+
+COPY elixir/ ./
+RUN MIX_ENV=prod mix build
+
+# Runtime stage: matches the build stage's OTP version so escript bytecode
+# loads correctly. Adds git, ssh, and the Claude Code CLI on top.
+FROM elixir:1.19-otp-28-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      nodejs \
+      npm \
+      openssh-client \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install -g @anthropic-ai/claude-code \
+ && npm cache clean --force
+
+COPY --from=build /app/bin/symphony /usr/local/bin/opal
+COPY docker/default-WORKFLOW.md /etc/opal/default-WORKFLOW.md
+COPY docker/entrypoint.sh /usr/local/bin/opal-entrypoint
+RUN chmod +x /usr/local/bin/opal /usr/local/bin/opal-entrypoint
+
+VOLUME /project
+VOLUME /workspace
+
+ENV WORKSPACE_ROOT=/workspace
+
+ENTRYPOINT ["/usr/local/bin/opal-entrypoint"]

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -1,0 +1,52 @@
+---
+# Sample WORKFLOW.md for projects that want Opal to work on their issues.
+# Drop this at your project root as `WORKFLOW.md`, fill in `repo`, and
+# run Opal via Docker (see docker/README.md).
+
+tracker:
+  kind: github                  # or "linear" / "memory"
+  repo: $GITHUB_REPO            # owner/repo — env var or hardcoded
+  api_key: $GITHUB_TOKEN        # GitHub PAT or App token
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+  # labels_prefix: "opal:"      # optional — namespace state labels
+
+agent:
+  runtime: claude-code          # or "codex"
+  max_concurrent_agents: 1      # how many issues to work in parallel
+  max_turns: 20                 # max agent turns per issue
+
+workspace:
+  root: /workspace              # where per-issue checkouts live
+
+polling:
+  interval_ms: 30000
+
+claude_code:
+  command: claude
+  permission_mode: acceptEdits
+  allowed_tools: "Edit,Write,Read,Bash,Glob,Grep"
+
+# Optional lifecycle hooks (shell commands).
+# hooks:
+#   after_create: "git clone $REPO_URL ."
+#   before_run: "make setup"
+#   after_run: "make test"
+---
+
+# Optional: project-specific prompt body (Liquid template).
+#
+# Leave this section empty to use Opal's built-in generic project-adaptive
+# prompt (which tells the agent to read your CLAUDE.md / AGENTS.md /
+# README.md / CONTRIBUTING.md and follow them as authoritative).
+#
+# Available template variables:
+#   {{ task.number }}       — issue identifier (e.g. "#42" or "MT-123")
+#   {{ task.title }}
+#   {{ task.description }}
+#   {{ task.state }}
+#   {{ task.labels }}        — list
+#   {{ task.url }}
+#   {{ attempt }}            — retry attempt number (only on retries)
+#
+# (Legacy `{{ issue.X }}` aliases also work.)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,73 @@
+# Opal Docker image
+
+Run Opal as a containerized agent orchestrator: mount any project, point it at
+GitHub Issues, and let Claude Code work the queue.
+
+## Build
+
+```bash
+docker build -t opal .
+```
+
+## Run
+
+The image expects two volumes and two environment variables:
+
+| Path / var      | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `/project`      | Bind-mount of the project Opal is working on   |
+| `/workspace`    | Bind-mount where per-issue workspaces are kept |
+| `GITHUB_TOKEN`  | GitHub PAT or GitHub App token                 |
+| `GITHUB_REPO`   | `owner/repo` (only used by the default config) |
+
+Minimal invocation:
+
+```bash
+docker run --rm -it \
+  -v "$PWD":/project \
+  -v /tmp/opal-workspaces:/workspace \
+  -e GITHUB_TOKEN=ghp_... \
+  -e GITHUB_REPO=owner/repo \
+  opal
+```
+
+## How the WORKFLOW.md is selected
+
+The entrypoint picks the first match it finds:
+
+1. `/project/WORKFLOW.md` — your project's own config and prompt override
+2. `/etc/opal/default-WORKFLOW.md` — the image's built-in default
+
+The default WORKFLOW.md ships with `tracker.kind: github`, `agent.runtime:
+claude-code`, and an empty prompt body — which causes Opal to use its built-in
+generic project-adaptive prompt. That prompt tells the agent to read your
+project's `CLAUDE.md` / `AGENTS.md` / `README.md` / `CONTRIBUTING.md` and
+follow them as authoritative.
+
+In other words: a project with no Opal-specific config gets sensible defaults.
+A project that wants to customize anything just drops a `WORKFLOW.md` at its
+root.
+
+## Project agent docs
+
+Claude Code auto-discovers the following from `cwd=/project`:
+
+- `CLAUDE.md` (system prompt)
+- `AGENTS.md`
+- `.claude/skills/`
+- `.claude/agents/`
+
+You don't need to do anything special — just have those files in your repo.
+
+## Customizing the prompt or config
+
+Drop a `WORKFLOW.md` at your project root with YAML front matter and an
+optional Liquid template body. See the repo-root `WORKFLOW.example.md` for a
+ready-to-copy starting point.
+
+## Image contents
+
+- Erlang/OTP 28 runtime
+- Opal escript at `/usr/local/bin/opal`
+- `git`, `openssh-client`, `nodejs`, `npm`
+- `claude` CLI from `@anthropic-ai/claude-code`

--- a/docker/default-WORKFLOW.md
+++ b/docker/default-WORKFLOW.md
@@ -1,0 +1,22 @@
+---
+tracker:
+  kind: github
+  repo: $GITHUB_REPO
+  api_key: $GITHUB_TOKEN
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agent:
+  runtime: claude-code
+  max_concurrent_agents: 1
+  max_turns: 20
+workspace:
+  root: /workspace
+polling:
+  interval_ms: 30000
+claude_code:
+  command: claude
+  permission_mode: acceptEdits
+  allowed_tools: "Edit,Write,Read,Bash,Glob,Grep"
+---
+
+(Empty body — Opal will use its built-in generic project-adaptive prompt.)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Opal Docker entrypoint.
+#
+# Selects the WORKFLOW.md to run with:
+#   1. If `/project/WORKFLOW.md` exists, use it (project provided one).
+#   2. Otherwise fall back to the baked-in `/etc/opal/default-WORKFLOW.md`.
+#
+# Working directory is set to /project so Claude Code auto-discovers the
+# project's own CLAUDE.md, AGENTS.md, .claude/skills/, .claude/agents/.
+#
+# The `--i-understand-...` guardrail flag is implicit when running inside
+# Docker — running this image is itself the explicit consent.
+
+set -eu
+
+PROJECT_DIR="${PROJECT_DIR:-/project}"
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-/workspace}"
+
+if [ -f "$PROJECT_DIR/WORKFLOW.md" ]; then
+  WORKFLOW_PATH="$PROJECT_DIR/WORKFLOW.md"
+else
+  WORKFLOW_PATH="/etc/opal/default-WORKFLOW.md"
+fi
+
+mkdir -p "$WORKSPACE_ROOT"
+cd "$PROJECT_DIR"
+
+exec /usr/local/bin/opal \
+  --i-understand-that-this-will-be-running-without-the-usual-guardrails \
+  "$@" \
+  "$WORKFLOW_PATH"

--- a/elixir/lib/symphony_elixir/cli.ex
+++ b/elixir/lib/symphony_elixir/cli.ex
@@ -113,9 +113,9 @@ defmodule SymphonyElixir.CLI do
   @spec acknowledgement_banner() :: String.t()
   defp acknowledgement_banner do
     lines = [
-      "This Symphony implementation is a low key engineering preview.",
-      "Codex will run without any guardrails.",
-      "SymphonyElixir is not a supported product and is presented as-is.",
+      "Opal is a low key engineering preview.",
+      "The configured agent runtime will run without any guardrails.",
+      "Opal is not a supported product and is presented as-is.",
       "To proceed, start with `--i-understand-that-this-will-be-running-without-the-usual-guardrails` CLI argument"
     ]
 

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -140,27 +140,28 @@ defmodule SymphonyElixir.Config do
   end
 
   defp validate_semantics(settings) do
+    case settings.tracker.kind do
+      nil -> {:error, :missing_tracker_kind}
+      "linear" -> validate_linear_tracker(settings.tracker)
+      "github" -> validate_github_tracker(settings.tracker)
+      "memory" -> :ok
+      kind -> {:error, {:unsupported_tracker_kind, kind}}
+    end
+  end
+
+  defp validate_linear_tracker(tracker) do
     cond do
-      is_nil(settings.tracker.kind) ->
-        {:error, :missing_tracker_kind}
+      not is_binary(tracker.api_key) -> {:error, :missing_linear_api_token}
+      not is_binary(tracker.project_slug) -> {:error, :missing_linear_project_slug}
+      true -> :ok
+    end
+  end
 
-      settings.tracker.kind not in ["linear", "memory", "github"] ->
-        {:error, {:unsupported_tracker_kind, settings.tracker.kind}}
-
-      settings.tracker.kind == "linear" and not is_binary(settings.tracker.api_key) ->
-        {:error, :missing_linear_api_token}
-
-      settings.tracker.kind == "linear" and not is_binary(settings.tracker.project_slug) ->
-        {:error, :missing_linear_project_slug}
-
-      settings.tracker.kind == "github" and not is_binary(settings.tracker.api_key) ->
-        {:error, :missing_github_api_token}
-
-      settings.tracker.kind == "github" and not is_binary(settings.tracker.repo) ->
-        {:error, :missing_github_repo}
-
-      true ->
-        :ok
+  defp validate_github_tracker(tracker) do
+    cond do
+      not is_binary(tracker.api_key) -> {:error, :missing_github_api_token}
+      not is_binary(tracker.repo) -> {:error, :missing_github_repo}
+      true -> :ok
     end
   end
 

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -6,17 +6,42 @@ defmodule SymphonyElixir.Config do
   alias SymphonyElixir.Config.Schema
   alias SymphonyElixir.Workflow
 
-  @default_prompt_template """
-  You are working on a Linear issue.
+  @default_prompt_template ~S"""
+  You are an autonomous coding agent working on task {{ task.number }}: {{ task.title }}
 
-  Identifier: {{ issue.identifier }}
-  Title: {{ issue.title }}
+  ## Task
 
-  Body:
-  {% if issue.description %}
-  {{ issue.description }}
+  {% if task.description %}
+  {{ task.description }}
   {% else %}
   No description provided.
+  {% endif %}
+
+  ## Project context
+
+  Read and follow the project's own documentation before doing anything else:
+
+  - `CLAUDE.md` (agent instructions, if present)
+  - `AGENTS.md` (agent conventions, if present)
+  - `README.md` (project overview)
+  - `CONTRIBUTING.md` (contribution conventions, if present)
+
+  Treat the project's own instructions as authoritative. They override any
+  generic guidance below when they conflict.
+
+  ## Execution rules
+
+  1. Understand the project first — read its docs, scan its structure, learn
+     its conventions.
+  2. Work autonomously. Do not ask for human input unless you are truly
+     blocked.
+  3. Follow the project's own testing, formatting, and code style conventions.
+  4. Create a branch, implement the change, run the project's tests, commit,
+     push, and open a pull request that links back to this task.
+
+  {% if attempt %}
+  This is retry attempt #{{ attempt }}. Resume from the current workspace
+  state instead of restarting from scratch.
   {% endif %}
   """
 

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -144,7 +144,7 @@ defmodule SymphonyElixir.Config do
       is_nil(settings.tracker.kind) ->
         {:error, :missing_tracker_kind}
 
-      settings.tracker.kind not in ["linear", "memory"] ->
+      settings.tracker.kind not in ["linear", "memory", "github"] ->
         {:error, {:unsupported_tracker_kind, settings.tracker.kind}}
 
       settings.tracker.kind == "linear" and not is_binary(settings.tracker.api_key) ->
@@ -152,6 +152,12 @@ defmodule SymphonyElixir.Config do
 
       settings.tracker.kind == "linear" and not is_binary(settings.tracker.project_slug) ->
         {:error, :missing_linear_project_slug}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.api_key) ->
+        {:error, :missing_github_api_token}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.repo) ->
+        {:error, :missing_github_repo}
 
       true ->
         :ok

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -409,7 +409,8 @@ defmodule SymphonyElixir.Config.Schema do
     tracker = %{
       settings.tracker
       | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env(api_key_fallback_env)),
-        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env(assignee_fallback_env))
+        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env(assignee_fallback_env)),
+        repo: resolve_secret_setting(settings.tracker.repo, System.get_env("GITHUB_REPO"))
     }
 
     workspace = %{

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -237,6 +237,14 @@ defmodule SymphonyElixir.Orchestrator do
         Logger.error("Linear project slug missing in WORKFLOW.md")
         state
 
+      {:error, :missing_github_api_token} ->
+        Logger.error("GitHub API token missing in WORKFLOW.md (set api_key or $GITHUB_TOKEN)")
+        state
+
+      {:error, :missing_github_repo} ->
+        Logger.error("GitHub repo missing in WORKFLOW.md (set tracker.repo or $GITHUB_REPO)")
+        state
+
       {:error, :missing_tracker_kind} ->
         Logger.error("Tracker kind missing in WORKFLOW.md")
 

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -1,6 +1,10 @@
 defmodule SymphonyElixir.PromptBuilder do
   @moduledoc """
-  Builds agent prompts from Linear issue data.
+  Builds agent prompts from issue data.
+
+  Templates can use either the legacy `issue.X` variable namespace or the
+  generic `task.X` namespace (added for tracker-agnostic templates). Both
+  point to the same underlying data; `task.number` aliases `issue.identifier`.
   """
 
   alias SymphonyElixir.{Config, Workflow}
@@ -14,11 +18,15 @@ defmodule SymphonyElixir.PromptBuilder do
       |> prompt_template!()
       |> parse_template!()
 
+    issue_map = issue |> Map.from_struct() |> to_solid_map()
+    task_map = Map.put(issue_map, "number", Map.get(issue_map, "identifier"))
+
     template
     |> Solid.render!(
       %{
         "attempt" => Keyword.get(opts, :attempt),
-        "issue" => issue |> Map.from_struct() |> to_solid_map()
+        "issue" => issue_map,
+        "task" => task_map
       },
       @render_opts
     )

--- a/elixir/test/symphony_elixir/cli_test.exs
+++ b/elixir/test/symphony_elixir/cli_test.exs
@@ -32,9 +32,9 @@ defmodule SymphonyElixir.CLITest do
     }
 
     assert {:error, banner} = CLI.evaluate(["WORKFLOW.md"], deps)
-    assert banner =~ "This Symphony implementation is a low key engineering preview."
-    assert banner =~ "Codex will run without any guardrails."
-    assert banner =~ "SymphonyElixir is not a supported product and is presented as-is."
+    assert banner =~ "Opal is a low key engineering preview."
+    assert banner =~ "The configured agent runtime will run without any guardrails."
+    assert banner =~ "Opal is not a supported product and is presented as-is."
     assert banner =~ @ack_flag
     refute_received :file_checked
     refute_received :workflow_set

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -786,6 +786,51 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "attempt=3"
   end
 
+  test "prompt builder exposes task.X alongside issue.X with task.number aliasing identifier" do
+    workflow_prompt =
+      "Task {{ task.number }} - {{ task.title }} state={{ task.state }} url={{ task.url }} labels={{ task.labels }}"
+
+    write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
+
+    issue = %Issue{
+      identifier: "MT-42",
+      title: "Add a thing",
+      description: "Body text",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-42",
+      labels: ["backend", "priority"]
+    }
+
+    prompt = PromptBuilder.build_prompt(issue)
+
+    assert prompt =~ "Task MT-42"
+    assert prompt =~ "Add a thing"
+    assert prompt =~ "state=In Progress"
+    assert prompt =~ "url=https://example.org/issues/MT-42"
+    assert prompt =~ "labels=backendpriority"
+  end
+
+  test "prompt builder still resolves legacy issue.X variables for backwards compat" do
+    workflow_prompt =
+      "Legacy issue={{ issue.identifier }} new task={{ task.number }} same? equal"
+
+    write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
+
+    issue = %Issue{
+      identifier: "MT-100",
+      title: "Compat",
+      description: nil,
+      state: "Todo",
+      url: "https://example.org/issues/MT-100",
+      labels: []
+    }
+
+    prompt = PromptBuilder.build_prompt(issue)
+
+    assert prompt =~ "Legacy issue=MT-100"
+    assert prompt =~ "new task=MT-100"
+  end
+
   test "prompt builder renders issue datetime fields without crashing" do
     workflow_prompt = "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
 
@@ -883,14 +928,17 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "You are working on a Linear issue."
-    assert prompt =~ "Identifier: MT-777"
-    assert prompt =~ "Title: Make fallback prompt useful"
-    assert prompt =~ "Body:"
+    assert prompt =~ "autonomous coding agent working on task MT-777"
+    assert prompt =~ "Make fallback prompt useful"
     assert prompt =~ "Include enough issue context to start working."
-    assert Config.workflow_prompt() =~ "{{ issue.identifier }}"
-    assert Config.workflow_prompt() =~ "{{ issue.title }}"
-    assert Config.workflow_prompt() =~ "{{ issue.description }}"
+    assert prompt =~ "Project context"
+    assert prompt =~ "CLAUDE.md"
+    assert prompt =~ "AGENTS.md"
+    assert prompt =~ "README.md"
+    assert prompt =~ "Execution rules"
+    assert Config.workflow_prompt() =~ "{{ task.number }}"
+    assert Config.workflow_prompt() =~ "{{ task.title }}"
+    assert Config.workflow_prompt() =~ "{{ task.description }}"
   end
 
   test "prompt builder default template handles missing issue body" do
@@ -907,8 +955,8 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "Identifier: MT-778"
-    assert prompt =~ "Title: Handle empty body"
+    assert prompt =~ "task MT-778"
+    assert prompt =~ "Handle empty body"
     assert prompt =~ "No description provided."
   end
 

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -86,6 +86,33 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "123")
     assert {:error, {:unsupported_tracker_kind, "123"}} = Config.validate!()
+
+    # github tracker requires repo + api_key
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: nil,
+      tracker_project_slug: nil
+    )
+
+    assert {:error, :missing_github_api_token} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "ghp_x",
+      tracker_project_slug: nil,
+      tracker_repo: nil
+    )
+
+    assert {:error, :missing_github_repo} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "ghp_x",
+      tracker_project_slug: nil,
+      tracker_repo: "owner/repo"
+    )
+
+    assert :ok = Config.validate!()
   end
 
   test "current WORKFLOW.md file is valid and complete" do


### PR DESCRIPTION
#### Context

With #1 (GitHub tracker) and #2 (Claude Code adapter) merged, Opal can run any project end-to-end. The remaining gaps were the Linear-specific default prompt (\`\"You are working on a Linear issue.\"\`) and the lack of a production Dockerfile. This PR closes both \u2014 Opal can now \`docker run -v \$PWD:/project -e GITHUB_TOKEN=\$T -e GITHUB_REPO=\$R opal\` against any repo and the agent will read that project's own \`CLAUDE.md\` / \`AGENTS.md\` / \`README.md\` to understand what to do.

#### TL;DR

*Generic project-adaptive default prompt + production Dockerfile that bundles the Claude Code CLI.*

#### Summary

- **Templates**: \`PromptBuilder\` now exposes \`task.X\` alongside legacy \`issue.X\` in Solid templates. \`task.number\` aliases \`issue.identifier\`. Both namespaces point at the same \`Linear.Issue\` data \u2014 no struct rename, fully backwards compatible
- **Default prompt**: rewritten in \`config.ex\` as a project-adaptive template that tells the agent to read \`CLAUDE.md\` / \`AGENTS.md\` / \`README.md\` / \`CONTRIBUTING.md\` and treat them as authoritative, then branch \u2192 implement \u2192 test \u2192 commit \u2192 push \u2192 PR
- **Config**: \`tracker.repo\` now resolves \`\$GITHUB_REPO\` env var (matches existing \`\$GITHUB_TOKEN\` pattern). CLI guardrail banner reworded to drop Codex-specific language
- **Dockerfile**: multi-stage build (\`elixir:1.19-otp-28\` build \u2192 \`elixir:1.19-otp-28-slim\` runtime so OTP versions match and escripts load). Bundles \`claude\` CLI via \`@anthropic-ai/claude-code\`. Thin entrypoint picks \`/project/WORKFLOW.md\` or falls back to the baked-in default. Default WORKFLOW.md uses \`\$GITHUB_REPO\` + empty prompt body so the generic template kicks in
- **Docs**: \`docker/README.md\` (build/run/customize), \`WORKFLOW.example.md\` at repo root for projects starting from scratch
- **3 new prompt tests**: task-alias renders, legacy issue-alias still works, default-prompt content updated

#### Alternatives

- **Full struct rename Linear.Issue \u2192 Task**: rejected as out of scope. Templates-only rename preserves backwards compatibility and matches the issue's literal acceptance criterion (\"not Linear-specific field names in templates\"). Struct rename can come as a followup
- **Debian bookworm runtime stage**: tried first \u2014 fails because Debian's \`erlang-base\` is OTP 25 and our build uses OTP 28, so the escript bytecode wouldn't load. Switched to \`elixir:1.19-otp-28-slim\` so build/runtime versions match
- **Pipe prompt as user message instead of CLI arg**: not applicable here \u2014 we're rendering the prompt template, the actual claude invocation is unchanged from #2
- **Replace \`elixir/WORKFLOW.md\` with the new generic template**: kept it as Opal's own dev workflow (Linear). \`WORKFLOW.example.md\` is the new sample for downstream projects

#### Test Plan

- [x] \`make -C elixir all\` (format, credo --strict, test+coverage 100%, dialyzer) \u2014 green locally
- [x] New tests: task-alias rendering, legacy issue compat, generic default prompt
- [x] Existing tests pass (45/45 + skips/excludes)
- [x] \`docker build -t opal .\` succeeds
- [x] \`docker run --rm opal --help\` \u2192 prints CLI usage
- [x] \`docker run -e GITHUB_TOKEN=... -e GITHUB_REPO=... opal\` \u2192 boots, parses env vars, starts orchestrator, shows status dashboard
- [ ] (Out of scope per #3 acceptance criteria) Full integration test mounting a real project

Closes #3