### PR TITLE
feat(docker): expose Phoenix LiveView dashboard on port 4000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,9 @@ VOLUME /workspace
 
 ENV WORKSPACE_ROOT=/workspace
 
+# Phoenix LiveView observability dashboard. The default WORKFLOW.md binds
+# this to 0.0.0.0:4000 inside the container; publish it with
+# `docker run -p 4000:4000 ...` to view from the host.
+EXPOSE 4000
+
 ENTRYPOINT ["/usr/local/bin/opal-entrypoint"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,12 +24,26 @@ Minimal invocation:
 
 ```bash
 docker run --rm -it \
+  -p 4000:4000 \
   -v "$PWD":/project \
   -v /tmp/opal-workspaces:/workspace \
   -e GITHUB_TOKEN=ghp_... \
   -e GITHUB_REPO=owner/repo \
   opal
 ```
+
+## Observability dashboard
+
+The Phoenix LiveView dashboard listens on port `4000` inside the container
+(bound to `0.0.0.0` by the default WORKFLOW.md). Publish the port with
+`-p 4000:4000` and open <http://localhost:4000> to watch live agent activity,
+token usage, rate limits, and the running/queued agent table.
+
+To pick a different host port, change the left side of `-p`, e.g.
+`-p 8080:4000` then visit <http://localhost:8080>.
+
+To disable the dashboard entirely, set `observability.dashboard_enabled:
+false` and/or remove the `server:` block in your project's `WORKFLOW.md`.
 
 ## How the WORKFLOW.md is selected
 

--- a/docker/default-WORKFLOW.md
+++ b/docker/default-WORKFLOW.md
@@ -17,6 +17,11 @@ claude_code:
   command: claude
   permission_mode: acceptEdits
   allowed_tools: "Edit,Write,Read,Bash,Glob,Grep"
+server:
+  # Bind to 0.0.0.0 so the dashboard is reachable from outside the container
+  # when started with `docker run -p 4000:4000 ...`.
+  host: "0.0.0.0"
+  port: 4000
 ---
 
 (Empty body — Opal will use its built-in generic project-adaptive prompt.)


### PR DESCRIPTION
#### Context

Opal ships a Phoenix LiveView observability dashboard (live agent activity, token usage, rate limits, running/queued agents) but it wasn't reachable from the host when running in Docker. Three things were stopping that:

- The default WORKFLOW.md didn't set \`server.port\`, so \`HttpServer.start_link\` returned \`:ignore\` and the endpoint never started
- Even with a port set, \`server.host\` defaulted to \`127.0.0.1\` (loopback only), which isn't reachable from outside the container's network namespace
- The Dockerfile didn't \`EXPOSE\` any ports

#### TL;DR

*Default WORKFLOW.md now binds the dashboard to 0.0.0.0:4000, Dockerfile EXPOSEs 4000, README documents \`-p 4000:4000\`.*

#### Summary

- \`docker/default-WORKFLOW.md\` adds a \`server\` block: \`host: \"0.0.0.0\"\`, \`port: 4000\`
- \`Dockerfile\` adds \`EXPOSE 4000\` with a comment explaining the \`-p 4000:4000\` pattern
- \`docker/README.md\` adds an \"Observability dashboard\" section, updates the minimal-invocation snippet to include \`-p 4000:4000\`, and documents how to remap the host port or disable the dashboard entirely

#### Alternatives

- **Set port via env var** instead of hard-coding 4000 in the default WORKFLOW.md \u2014 rejected as overkill; users who want a different port can drop their own \`/project/WORKFLOW.md\` (which is the documented customization path) or change the host side of \`-p\`
- **Auto-EXPOSE all of 4000-4010** \u2014 unnecessary; one port is enough and matches the default config

#### Test Plan

- [x] \`docker build -t opal .\` succeeds
- [x] \`docker run --rm -d -p 4000:4000 -e GITHUB_TOKEN=... -e GITHUB_REPO=... opal\` starts cleanly
- [x] \`curl -s http://localhost:4000/\` returns HTTP 200 with the \"Symphony Observability\" LiveView page (6441 bytes, includes phoenix_live_view.js + dashboard markup)
- [x] \`docker port\` shows \`4000/tcp -> 0.0.0.0:4000\`