### PR TITLE
feat: per-project knowledge subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ extended with:
 - **GitHub Issues** as the task source (replacing Linear)
 - **Claude Code** (`claude -p`) as the agent runtime (replacing Codex)
 - **Project-adaptive prompts** that read your project's own CLAUDE.md / README and follow them
+- **Per-project knowledge** — Opal accumulates experience knowledge per target project and injects
+  it into each agent run, without polluting the target repo
 - **Docker packaging** for drop-in use with any codebase
 
 > [!WARNING]
@@ -42,6 +44,8 @@ The codebase is forked from [openai/symphony](https://github.com/openai/symphony
 
 - **Orchestrator** — GenServer polling loop with concurrency, retries, and reconciliation
 - **Workspace manager** — per-issue isolation with lifecycle hooks
+- **Knowledge subsystem** — per-project experience knowledge, filesystem-backed by default,
+  dynamically injected into each agent run (see SPEC §9.6)
 - **Prompt builder** — Liquid template rendering with task context
 - **Observability** — terminal dashboard + Phoenix LiveView UI
 - **SPEC.md** — language-agnostic specification for building your own

--- a/SPEC.md
+++ b/SPEC.md
@@ -897,6 +897,38 @@ Invariant 3: Workspace key is sanitized.
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
 - Replace all other characters with `_`.
 
+### 9.6 Project Knowledge Injection (Optional)
+
+Implementations MAY inject per-project experience knowledge into the workspace
+before the coding-agent subprocess is launched. The purpose is to give the
+agent accumulated learnings about the target project (gotchas, conventions,
+curated skills) without the target repository itself having to hold
+Opal-authored artifacts.
+
+Injection contract:
+
+- Knowledge is keyed by a stable `project_key` derived from existing config
+  (e.g. `<kind>_<owner>_<repo>` for GitHub trackers).
+- Knowledge is stored by Opal, outside the target repo. A `knowledge_root`
+  location holds one directory per `project_key`.
+- Each project directory MAY contain:
+  - `CLAUDE.md` — always-loaded index.
+  - `skills/<name>/SKILL.md` — on-demand procedural skills (loaded by the
+    coding agent's native description-match mechanism).
+  - `memory/<topic>.md` — accumulated topical learnings.
+- Before the agent runs, the implementation copies the project's tree into the
+  workspace under `<workspace>/.claude/` and ensures `<workspace>/CLAUDE.md`
+  imports the project index via `@.claude/opal-knowledge.md`.
+- If the target repository already contains a `CLAUDE.md`, implementations
+  MUST NOT overwrite it. The import line is appended instead.
+- Injection MUST be idempotent — re-running on the same workspace produces the
+  same final state without duplicating imports.
+- When the knowledge tree is empty for a `project_key`, injection is a no-op.
+
+Storage backend is pluggable. Implementations SHOULD ship a filesystem backend
+by default and MAY layer git-backed, database-backed, or object-storage
+backends on top of the same boundary.
+
 ## 10. Agent Runner Protocol (Coding Agent Integration)
 
 This section defines the language-neutral contract for integrating a coding agent app-server.

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -293,6 +293,31 @@ defmodule SymphonyElixir.Config.Schema do
     end
   end
 
+  defmodule Knowledge do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @default_root Path.join(System.tmp_dir!(), "opal_knowledge")
+
+    @spec default_root() :: String.t()
+    def default_root, do: @default_root
+
+    @primary_key false
+    embedded_schema do
+      field(:backend, :string, default: "filesystem")
+      field(:root, :string, default: @default_root)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(attrs, [:backend, :root], empty_values: [])
+      |> validate_inclusion(:backend, ["filesystem"])
+      |> validate_required([:root])
+    end
+  end
+
   embedded_schema do
     embeds_one(:tracker, Tracker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:polling, Polling, on_replace: :update, defaults_to_struct: true)
@@ -304,6 +329,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:hooks, Hooks, on_replace: :update, defaults_to_struct: true)
     embeds_one(:observability, Observability, on_replace: :update, defaults_to_struct: true)
     embeds_one(:server, Server, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:knowledge, Knowledge, on_replace: :update, defaults_to_struct: true)
   end
 
   @spec parse(map()) :: {:ok, %__MODULE__{}} | {:error, {:invalid_workflow_config, String.t()}}
@@ -397,6 +423,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:hooks, with: &Hooks.changeset/2)
     |> cast_embed(:observability, with: &Observability.changeset/2)
     |> cast_embed(:server, with: &Server.changeset/2)
+    |> cast_embed(:knowledge, with: &Knowledge.changeset/2)
   end
 
   defp finalize_settings(settings) do
@@ -418,13 +445,18 @@ defmodule SymphonyElixir.Config.Schema do
       | root: resolve_path_value(settings.workspace.root, Path.join(System.tmp_dir!(), "symphony_workspaces"))
     }
 
+    knowledge = %{
+      settings.knowledge
+      | root: resolve_path_value(settings.knowledge.root, Knowledge.default_root())
+    }
+
     codex = %{
       settings.codex
       | approval_policy: normalize_keys(settings.codex.approval_policy),
         turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy)
     }
 
-    %{settings | tracker: tracker, workspace: workspace, codex: codex}
+    %{settings | tracker: tracker, workspace: workspace, codex: codex, knowledge: knowledge}
   end
 
   defp normalize_keys(value) when is_map(value) do

--- a/elixir/lib/symphony_elixir/knowledge.ex
+++ b/elixir/lib/symphony_elixir/knowledge.ex
@@ -130,12 +130,7 @@ defmodule SymphonyElixir.Knowledge do
     case Application.get_env(:symphony_elixir, :knowledge_store_module) do
       nil ->
         case Config.settings!().knowledge.backend do
-          "filesystem" ->
-            SymphonyElixir.Knowledge.Store.Filesystem
-
-          other ->
-            raise ArgumentError,
-                  "unsupported knowledge backend #{inspect(other)} — schema validation should have prevented this"
+          "filesystem" -> SymphonyElixir.Knowledge.Store.Filesystem
         end
 
       mod when is_atom(mod) ->

--- a/elixir/lib/symphony_elixir/knowledge.ex
+++ b/elixir/lib/symphony_elixir/knowledge.ex
@@ -1,0 +1,145 @@
+defmodule SymphonyElixir.Knowledge do
+  @moduledoc """
+  Opal's per-project experience-knowledge subsystem.
+
+  Holds accumulated learnings (CLAUDE.md, skills, memory) per target project
+  outside the target repo, and injects the active project's knowledge into an
+  agent workspace before `claude -p` spawns.
+
+  Contract with Claude Code's native loader:
+  * `<workspace>/CLAUDE.md` imports `@.claude/opal-knowledge.md`.
+  * `<workspace>/.claude/opal-knowledge.md` contains the project's CLAUDE.md body.
+  * `<workspace>/.claude/skills/` and `<workspace>/.claude/memory/` mirror the
+    project's knowledge tree.
+  """
+
+  require Logger
+
+  alias SymphonyElixir.Config
+  alias SymphonyElixir.Knowledge.Store
+
+  @opal_knowledge_rel_path ".claude/opal-knowledge.md"
+  @opal_knowledge_import "@.claude/opal-knowledge.md"
+
+  @spec inject(Path.t(), String.t()) :: :ok | {:error, term()}
+  def inject(workspace, project_key)
+      when is_binary(workspace) and is_binary(project_key) do
+    knowledge = Config.settings!().knowledge
+
+    case store_module().load(knowledge.root, project_key) do
+      {:ok, tree} ->
+        inject_tree(workspace, tree)
+
+      {:error, reason} = error ->
+        Logger.warning("Knowledge load failed project_key=#{project_key} reason=#{inspect(reason)}")
+
+        error
+    end
+  end
+
+  @spec inject_tree(Path.t(), Store.tree()) :: :ok
+  def inject_tree(workspace, %{files: files})
+      when is_binary(workspace) and is_map(files) do
+    Enum.each(files, fn {relative_path, content} ->
+      case relative_path do
+        "CLAUDE.md" ->
+          write_workspace_file(workspace, @opal_knowledge_rel_path, content)
+          ensure_claude_md_import(workspace)
+
+        other ->
+          write_workspace_file(workspace, Path.join(".claude", other), content)
+      end
+    end)
+
+    :ok
+  end
+
+  @spec capture(String.t(), String.t(), binary()) :: :ok | {:error, term()}
+  def capture(project_key, relative_path, content)
+      when is_binary(project_key) and is_binary(relative_path) and is_binary(content) do
+    knowledge = Config.settings!().knowledge
+    store_module().write(knowledge.root, project_key, relative_path, content)
+  end
+
+  @spec load(String.t()) :: {:ok, Store.tree()} | {:error, term()}
+  def load(project_key) when is_binary(project_key) do
+    knowledge = Config.settings!().knowledge
+    store_module().load(knowledge.root, project_key)
+  end
+
+  @spec project_key() :: String.t()
+  def project_key do
+    Config.settings!().tracker |> project_key_for()
+  end
+
+  @spec project_key_for(map() | struct()) :: String.t()
+  def project_key_for(tracker) do
+    kind = Map.get(tracker, :kind) || "unknown"
+
+    raw_slug =
+      case kind do
+        "github" -> Map.get(tracker, :repo) || "unknown"
+        "linear" -> Map.get(tracker, :project_slug) || "unknown"
+        "memory" -> Map.get(tracker, :project_slug) || "default"
+        _ -> "unknown"
+      end
+
+    kind <> "_" <> sanitize_slug(raw_slug)
+  end
+
+  defp sanitize_slug(slug) when is_binary(slug) do
+    slug
+    |> String.replace(~r/[^a-zA-Z0-9._-]/, "_")
+    |> String.replace(~r/_+/, "_")
+    |> String.trim("_")
+  end
+
+  defp write_workspace_file(workspace, relative_path, content) do
+    target = Path.join(workspace, relative_path)
+    File.mkdir_p!(Path.dirname(target))
+    File.write!(target, content)
+  end
+
+  defp ensure_claude_md_import(workspace) do
+    claude_md_path = Path.join(workspace, "CLAUDE.md")
+
+    existing =
+      case File.read(claude_md_path) do
+        {:ok, content} -> content
+        {:error, :enoent} -> ""
+      end
+
+    case String.contains?(existing, @opal_knowledge_import) do
+      true ->
+        :ok
+
+      false ->
+        joiner = if existing == "" or String.ends_with?(existing, "\n"), do: "", else: "\n"
+        separator = if existing == "", do: "", else: "\n"
+
+        File.write!(
+          claude_md_path,
+          existing <> joiner <> separator <> @opal_knowledge_import <> "\n"
+        )
+
+        :ok
+    end
+  end
+
+  defp store_module do
+    case Application.get_env(:symphony_elixir, :knowledge_store_module) do
+      nil ->
+        case Config.settings!().knowledge.backend do
+          "filesystem" ->
+            SymphonyElixir.Knowledge.Store.Filesystem
+
+          other ->
+            raise ArgumentError,
+                  "unsupported knowledge backend #{inspect(other)} — schema validation should have prevented this"
+        end
+
+      mod when is_atom(mod) ->
+        mod
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/knowledge/store.ex
+++ b/elixir/lib/symphony_elixir/knowledge/store.ex
@@ -1,0 +1,18 @@
+defmodule SymphonyElixir.Knowledge.Store do
+  @moduledoc """
+  Storage boundary for Opal's per-project experience knowledge.
+
+  Implementations persist a project's knowledge tree (CLAUDE.md, skills, memory)
+  keyed by a stable project slug. The filesystem implementation is the default;
+  git-backed, Postgres-backed, and S3-backed backends may plug in later.
+  """
+
+  @type project_key :: String.t()
+  @type relative_path :: String.t()
+  @type tree :: %{files: %{relative_path() => binary()}}
+
+  @callback load(root :: String.t(), project_key()) :: {:ok, tree()} | {:error, term()}
+  @callback write(root :: String.t(), project_key(), relative_path(), binary()) ::
+              :ok | {:error, term()}
+  @callback list_projects(root :: String.t()) :: {:ok, [project_key()]} | {:error, term()}
+end

--- a/elixir/lib/symphony_elixir/knowledge/store/filesystem.ex
+++ b/elixir/lib/symphony_elixir/knowledge/store/filesystem.ex
@@ -1,0 +1,88 @@
+defmodule SymphonyElixir.Knowledge.Store.Filesystem do
+  @moduledoc """
+  Filesystem-backed `SymphonyElixir.Knowledge.Store`.
+
+  Layout per project: `<root>/<project_key>/CLAUDE.md + skills/ + memory/`.
+  """
+
+  @behaviour SymphonyElixir.Knowledge.Store
+
+  @impl true
+  @spec load(String.t(), String.t()) :: {:ok, SymphonyElixir.Knowledge.Store.tree()}
+  def load(root, project_key) when is_binary(root) and is_binary(project_key) do
+    project_dir = Path.join(root, project_key)
+
+    case File.dir?(project_dir) do
+      true -> {:ok, %{files: collect_files(project_dir)}}
+      false -> {:ok, %{files: %{}}}
+    end
+  end
+
+  @impl true
+  @spec write(String.t(), String.t(), String.t(), binary()) :: :ok | {:error, term()}
+  def write(root, project_key, relative_path, content)
+      when is_binary(root) and is_binary(project_key) and is_binary(relative_path) and
+             is_binary(content) do
+    with :ok <- validate_relative_path(relative_path) do
+      target = Path.join([root, project_key, relative_path])
+      File.mkdir_p!(Path.dirname(target))
+      File.write!(target, content)
+      :ok
+    end
+  end
+
+  @impl true
+  @spec list_projects(String.t()) :: {:ok, [String.t()]}
+  def list_projects(root) when is_binary(root) do
+    case File.ls(root) do
+      {:ok, entries} ->
+        projects =
+          entries
+          |> Enum.filter(&File.dir?(Path.join(root, &1)))
+          |> Enum.sort()
+
+        {:ok, projects}
+
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp collect_files(project_dir) do
+    project_dir
+    |> list_all_files()
+    |> Enum.reduce(%{}, fn absolute_path, acc ->
+      relative = Path.relative_to(absolute_path, project_dir)
+      Map.put(acc, relative, File.read!(absolute_path))
+    end)
+  end
+
+  defp list_all_files(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.flat_map(fn entry ->
+      full = Path.join(dir, entry)
+
+      case File.dir?(full) do
+        true -> list_all_files(full)
+        false -> [full]
+      end
+    end)
+  end
+
+  defp validate_relative_path(path) do
+    cond do
+      String.starts_with?(path, "/") ->
+        {:error, {:unsafe_relative_path, path}}
+
+      String.contains?(path, "..") ->
+        {:error, {:unsafe_relative_path, path}}
+
+      true ->
+        :ok
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -4,7 +4,7 @@ defmodule SymphonyElixir.Workspace do
   """
 
   require Logger
-  alias SymphonyElixir.{Config, PathSafety, SSH}
+  alias SymphonyElixir.{Config, Knowledge, PathSafety, SSH}
 
   @remote_workspace_marker "__SYMPHONY_WORKSPACE__"
 
@@ -21,7 +21,8 @@ defmodule SymphonyElixir.Workspace do
       with {:ok, workspace} <- workspace_path_for_issue(safe_id, worker_host),
            :ok <- validate_workspace_path(workspace, worker_host),
            {:ok, workspace, created?} <- ensure_workspace(workspace, worker_host),
-           :ok <- maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do
+           :ok <- maybe_run_after_create_hook(workspace, issue_context, created?, worker_host),
+           :ok <- maybe_inject_knowledge(workspace, worker_host) do
         {:ok, workspace}
       end
     rescue
@@ -205,6 +206,25 @@ defmodule SymphonyElixir.Workspace do
 
   defp safe_identifier(identifier) do
     String.replace(identifier || "issue", ~r/[^a-zA-Z0-9._-]/, "_")
+  end
+
+  defp maybe_inject_knowledge(_workspace, worker_host) when is_binary(worker_host) do
+    Logger.info("Skipping knowledge injection on remote worker worker_host=#{worker_host}")
+    :ok
+  end
+
+  defp maybe_inject_knowledge(workspace, nil) do
+    project_key = Knowledge.project_key()
+
+    case Knowledge.inject(workspace, project_key) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Knowledge injection failed workspace=#{workspace} project_key=#{project_key} reason=#{inspect(reason)}")
+
+        :ok
+    end
   end
 
   defp maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do

--- a/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/CLAUDE.md
+++ b/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/CLAUDE.md
@@ -1,0 +1,22 @@
+# Opal knowledge: apexphere/opal-test-tracker
+
+This file is loaded into every agent run Opal spawns for the
+`apexphere/opal-test-tracker` repository. Content here is Opal-authored
+experience knowledge; it does not live in the target repo.
+
+## Active conventions
+
+- State labels: `todo` / `in-progress` / `human-review`. Closing the GitHub
+  issue represents the `Done` state.
+- Comment on issues with run summaries. Keep summaries terse — past runs have
+  accumulated noise that a human reviewer had to ignore.
+
+## Known pitfalls
+
+- GitHub's `labels` query parameter is AND, not OR. Query each state label
+  separately and merge results. (Captured during PR #4 implementation.)
+
+## See also
+
+- `memory/MEMORY.md` — index of topical learnings.
+- `skills/` — procedural how-tos loaded on-demand by description match.

--- a/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/memory/MEMORY.md
+++ b/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/memory/MEMORY.md
@@ -1,0 +1,1 @@
+- [Label semantics](label_semantics.md) — state machine via label swaps, not a `state` field

--- a/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/memory/label_semantics.md
+++ b/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/memory/label_semantics.md
@@ -1,0 +1,20 @@
+---
+name: Label semantics for opal-test-tracker
+description: How Opal maps issue state to GitHub labels on this repo
+type: reference
+---
+
+The tracker adapter encodes issue state as labels, not a native field.
+
+**Mapping:**
+- `todo` label → `Todo` state
+- `in-progress` label → `In Progress` state
+- `human-review` label → awaiting human review
+- issue closed → `Done` state (no terminal label; closure is the signal)
+
+**Why:** GitHub Issues has no native state machine beyond open/closed. Labels
+are the closest thing to a state field that's queryable via the REST API.
+
+**How to apply:** Transitions swap labels atomically — remove the old state
+label, add the new. Never leave two state labels on one issue. When moving
+to Done, close the issue and remove all state labels.

--- a/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/skills/summarize_run/SKILL.md
+++ b/elixir/priv/knowledge_examples/github_apexphere_opal-test-tracker/skills/summarize_run/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: summarize_run
+description: Produce a terse run summary comment for a GitHub Issue after completing work. Use when the run is about to close the issue or hand back to human-review.
+---
+
+# Summarize run
+
+## Goal
+
+Write a concise comment the reviewer can read in <30 seconds.
+
+## Structure
+
+1. What changed — files + high-level intent.
+2. How it was verified — tests run, manual checks performed.
+3. Anything the reviewer should look at closely.
+4. Open questions, if any.
+
+## Rules
+
+- Keep under 15 lines. Past runs have accumulated noise reviewers had to skim past.
+- No diff blocks. Link the commit / PR instead.
+- If you couldn't verify something, say so explicitly rather than glossing over.

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -133,6 +133,8 @@ defmodule SymphonyElixir.TestSupport do
           observability_render_interval_ms: 16,
           server_port: nil,
           server_host: nil,
+          knowledge_backend: nil,
+          knowledge_root: nil,
           prompt: @workflow_prompt
         ],
         overrides
@@ -179,6 +181,8 @@ defmodule SymphonyElixir.TestSupport do
     observability_render_interval_ms = Keyword.get(config, :observability_render_interval_ms)
     server_port = Keyword.get(config, :server_port)
     server_host = Keyword.get(config, :server_host)
+    knowledge_backend = Keyword.get(config, :knowledge_backend)
+    knowledge_root = Keyword.get(config, :knowledge_root)
     prompt = Keyword.get(config, :prompt)
 
     sections =
@@ -223,6 +227,7 @@ defmodule SymphonyElixir.TestSupport do
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),
+        knowledge_yaml(knowledge_backend, knowledge_root),
         "---",
         prompt
       ]
@@ -300,6 +305,18 @@ defmodule SymphonyElixir.TestSupport do
       "server:",
       port && "  port: #{yaml_value(port)}",
       host && "  host: #{yaml_value(host)}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp knowledge_yaml(nil, nil), do: nil
+
+  defp knowledge_yaml(backend, root) do
+    [
+      "knowledge:",
+      backend && "  backend: #{yaml_value(backend)}",
+      root && "  root: #{yaml_value(root)}"
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")

--- a/elixir/test/symphony_elixir/knowledge/store/filesystem_test.exs
+++ b/elixir/test/symphony_elixir/knowledge/store/filesystem_test.exs
@@ -1,0 +1,85 @@
+defmodule SymphonyElixir.Knowledge.Store.FilesystemTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Knowledge.Store.Filesystem
+
+  setup do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-fs-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf(root) end)
+    %{root: root}
+  end
+
+  describe "list_projects/1" do
+    test "returns empty list when root has no projects", %{root: root} do
+      assert {:ok, []} = Filesystem.list_projects(root)
+    end
+
+    test "returns project slugs sorted", %{root: root} do
+      File.mkdir_p!(Path.join(root, "apexphere_opal"))
+      File.mkdir_p!(Path.join(root, "apexphere_tradingagentharness"))
+
+      assert {:ok, ["apexphere_opal", "apexphere_tradingagentharness"]} =
+               Filesystem.list_projects(root)
+    end
+
+    test "returns empty list when root does not exist yet" do
+      missing = Path.join(System.tmp_dir!(), "opal-knowledge-missing-#{System.unique_integer([:positive])}")
+
+      assert {:ok, []} = Filesystem.list_projects(missing)
+    end
+  end
+
+  describe "load/2" do
+    test "returns empty tree for unknown project (auto-create contract)", %{root: root} do
+      assert {:ok, %{files: %{}}} = Filesystem.load(root, "apexphere_tradingagentharness")
+    end
+
+    test "returns files map with relative paths to contents", %{root: root} do
+      project_dir = Path.join(root, "apexphere_opal")
+      File.mkdir_p!(Path.join(project_dir, "memory"))
+      File.mkdir_p!(Path.join(project_dir, "skills/commit"))
+      File.write!(Path.join(project_dir, "CLAUDE.md"), "# Opal knowledge\n")
+      File.write!(Path.join(project_dir, "memory/MEMORY.md"), "- [note](note.md)\n")
+      File.write!(Path.join(project_dir, "skills/commit/SKILL.md"), "---\nname: commit\n---\n")
+
+      assert {:ok, %{files: files}} = Filesystem.load(root, "apexphere_opal")
+
+      assert files["CLAUDE.md"] == "# Opal knowledge\n"
+      assert files["memory/MEMORY.md"] == "- [note](note.md)\n"
+      assert files["skills/commit/SKILL.md"] == "---\nname: commit\n---\n"
+    end
+  end
+
+  describe "write/4" do
+    test "creates parent directories and writes file", %{root: root} do
+      assert :ok =
+               Filesystem.write(root, "apexphere_opal", "memory/new.md", "body\n")
+
+      assert File.read!(Path.join([root, "apexphere_opal", "memory", "new.md"])) ==
+               "body\n"
+    end
+
+    test "rejects relative path that escapes project dir", %{root: root} do
+      assert {:error, {:unsafe_relative_path, "../escape.md"}} =
+               Filesystem.write(root, "apexphere_opal", "../escape.md", "nope")
+    end
+
+    test "rejects absolute relative_path", %{root: root} do
+      assert {:error, {:unsafe_relative_path, "/etc/passwd"}} =
+               Filesystem.write(root, "apexphere_opal", "/etc/passwd", "nope")
+    end
+
+    test "overwrites existing file (idempotent)", %{root: root} do
+      :ok = Filesystem.write(root, "apexphere_opal", "CLAUDE.md", "v1")
+      :ok = Filesystem.write(root, "apexphere_opal", "CLAUDE.md", "v2")
+
+      assert File.read!(Path.join([root, "apexphere_opal", "CLAUDE.md"])) == "v2"
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/knowledge/store/filesystem_test.exs
+++ b/elixir/test/symphony_elixir/knowledge/store/filesystem_test.exs
@@ -33,6 +33,13 @@ defmodule SymphonyElixir.Knowledge.Store.FilesystemTest do
 
       assert {:ok, []} = Filesystem.list_projects(missing)
     end
+
+    test "propagates filesystem errors other than :enoent", %{root: root} do
+      file_as_root = Path.join(root, "not-a-dir")
+      File.write!(file_as_root, "this is a file, not a directory\n")
+
+      assert {:error, :enotdir} = Filesystem.list_projects(file_as_root)
+    end
   end
 
   describe "load/2" do

--- a/elixir/test/symphony_elixir/knowledge_integration_test.exs
+++ b/elixir/test/symphony_elixir/knowledge_integration_test.exs
@@ -1,0 +1,152 @@
+defmodule SymphonyElixir.KnowledgeIntegrationTest do
+  use SymphonyElixir.TestSupport
+
+  test "workspace creation injects seeded project knowledge into .claude/" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-integ-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      knowledge_root = Path.join(test_root, "knowledge")
+
+      project_key = "github_apexphere_opal-test-tracker"
+      project_dir = Path.join(knowledge_root, project_key)
+      File.mkdir_p!(Path.join(project_dir, "memory"))
+      File.mkdir_p!(Path.join(project_dir, "skills/summarize_run"))
+      File.write!(Path.join(project_dir, "CLAUDE.md"), "# Seeded knowledge\n")
+      File.write!(Path.join(project_dir, "memory/MEMORY.md"), "- [note](note.md)\n")
+
+      File.write!(
+        Path.join(project_dir, "skills/summarize_run/SKILL.md"),
+        "---\nname: summarize_run\n---\n"
+      )
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        tracker_kind: "github",
+        tracker_repo: "apexphere/opal-test-tracker",
+        knowledge_root: knowledge_root
+      )
+
+      assert {:ok, workspace} = Workspace.create_for_issue("INT-1")
+
+      assert File.read!(Path.join(workspace, ".claude/opal-knowledge.md")) ==
+               "# Seeded knowledge\n"
+
+      assert File.read!(Path.join(workspace, ".claude/memory/MEMORY.md")) ==
+               "- [note](note.md)\n"
+
+      assert File.read!(Path.join(workspace, ".claude/skills/summarize_run/SKILL.md")) =~
+               "name: summarize_run"
+
+      claude_md = File.read!(Path.join(workspace, "CLAUDE.md"))
+      assert claude_md =~ "@.claude/opal-knowledge.md"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "workspace creation is a no-op on knowledge when project has no seeded tree" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-integ-empty-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      knowledge_root = Path.join(test_root, "knowledge")
+      File.mkdir_p!(knowledge_root)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        tracker_kind: "github",
+        tracker_repo: "apexphere/never-seeded",
+        knowledge_root: knowledge_root
+      )
+
+      assert {:ok, workspace} = Workspace.create_for_issue("EMPTY-1")
+
+      refute File.exists?(Path.join(workspace, ".claude/opal-knowledge.md"))
+      refute File.exists?(Path.join(workspace, "CLAUDE.md"))
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "Knowledge.capture/3 writes into the configured knowledge root" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-capture-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      knowledge_root = Path.join(test_root, "knowledge")
+      File.mkdir_p!(knowledge_root)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "github",
+        tracker_repo: "apexphere/opal-test-tracker",
+        knowledge_root: knowledge_root
+      )
+
+      assert :ok =
+               SymphonyElixir.Knowledge.capture(
+                 "github_apexphere_opal-test-tracker",
+                 "memory/new_topic.md",
+                 "- captured entry\n"
+               )
+
+      assert File.read!(
+               Path.join([
+                 knowledge_root,
+                 "github_apexphere_opal-test-tracker",
+                 "memory/new_topic.md"
+               ])
+             ) == "- captured entry\n"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "workspace creation preserves target repo's native CLAUDE.md and appends import" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-integ-coexist-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      knowledge_root = Path.join(test_root, "knowledge")
+
+      project_key = "github_apexphere_opal-test-tracker"
+      project_dir = Path.join(knowledge_root, project_key)
+      File.mkdir_p!(project_dir)
+      File.write!(Path.join(project_dir, "CLAUDE.md"), "# Opal-authored\n")
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        tracker_kind: "github",
+        tracker_repo: "apexphere/opal-test-tracker",
+        hook_after_create: "printf '# Target repo native\\n' > CLAUDE.md",
+        knowledge_root: knowledge_root
+      )
+
+      assert {:ok, workspace} = Workspace.create_for_issue("COEX-1")
+
+      claude_md = File.read!(Path.join(workspace, "CLAUDE.md"))
+      assert claude_md =~ "# Target repo native"
+      assert claude_md =~ "@.claude/opal-knowledge.md"
+
+      assert File.read!(Path.join(workspace, ".claude/opal-knowledge.md")) =~
+               "# Opal-authored"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/knowledge_integration_test.exs
+++ b/elixir/test/symphony_elixir/knowledge_integration_test.exs
@@ -1,6 +1,100 @@
 defmodule SymphonyElixir.KnowledgeIntegrationTest do
   use SymphonyElixir.TestSupport
 
+  defmodule FakeFailingStore do
+    @behaviour SymphonyElixir.Knowledge.Store
+
+    @impl true
+    def load(_root, _project_key), do: {:error, :store_unavailable}
+
+    @impl true
+    def write(_root, _project_key, _path, _content), do: :ok
+
+    @impl true
+    def list_projects(_root), do: {:ok, []}
+  end
+
+  defmodule FakeEchoStore do
+    @behaviour SymphonyElixir.Knowledge.Store
+
+    @impl true
+    def load(root, project_key),
+      do: {:ok, %{files: %{"echo" => "root=#{root} key=#{project_key}"}}}
+
+    @impl true
+    def write(_root, _project_key, _path, _content), do: :ok
+
+    @impl true
+    def list_projects(_root), do: {:ok, []}
+  end
+
+  defp with_store_module(module, fun) do
+    Application.put_env(:symphony_elixir, :knowledge_store_module, module)
+
+    try do
+      fun.()
+    after
+      Application.delete_env(:symphony_elixir, :knowledge_store_module)
+    end
+  end
+
+  test "Knowledge.inject/2 returns the store error and logs when load fails" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-inject-err-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(test_root)
+    on_exit(fn -> File.rm_rf(test_root) end)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_repo: "apexphere/opal-test-tracker",
+      knowledge_root: Path.join(test_root, "knowledge")
+    )
+
+    workspace = Path.join(test_root, "workspace")
+    File.mkdir_p!(workspace)
+
+    log =
+      capture_log(fn ->
+        assert {:error, :store_unavailable} =
+                 with_store_module(FakeFailingStore, fn ->
+                   SymphonyElixir.Knowledge.inject(workspace, "github_some_project")
+                 end)
+      end)
+
+    assert log =~ "Knowledge load failed"
+    assert log =~ "github_some_project"
+  end
+
+  test "Knowledge.load/1 delegates to the configured store" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "opal-knowledge-load-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(test_root)
+    on_exit(fn -> File.rm_rf(test_root) end)
+
+    knowledge_root = Path.join(test_root, "knowledge")
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_repo: "apexphere/opal-test-tracker",
+      knowledge_root: knowledge_root
+    )
+
+    assert {:ok, %{files: files}} =
+             with_store_module(FakeEchoStore, fn ->
+               SymphonyElixir.Knowledge.load("github_some_project")
+             end)
+
+    assert files["echo"] == "root=#{knowledge_root} key=github_some_project"
+  end
+
   test "workspace creation injects seeded project knowledge into .claude/" do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/knowledge_test.exs
+++ b/elixir/test/symphony_elixir/knowledge_test.exs
@@ -116,5 +116,10 @@ defmodule SymphonyElixir.KnowledgeTest do
       tracker = %{kind: "github", repo: "owner/repo with spaces", project_slug: nil}
       assert Knowledge.project_key_for(tracker) == "github_owner_repo_with_spaces"
     end
+
+    test "unrecognized kind falls back to unknown slug" do
+      tracker = %{kind: "jira", repo: nil, project_slug: nil}
+      assert Knowledge.project_key_for(tracker) == "jira_unknown"
+    end
   end
 end

--- a/elixir/test/symphony_elixir/knowledge_test.exs
+++ b/elixir/test/symphony_elixir/knowledge_test.exs
@@ -1,0 +1,120 @@
+defmodule SymphonyElixir.KnowledgeTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.Knowledge
+
+  describe "inject_tree/2" do
+    setup do
+      workspace =
+        Path.join(
+          System.tmp_dir!(),
+          "opal-knowledge-ws-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(workspace)
+      on_exit(fn -> File.rm_rf(workspace) end)
+      %{workspace: workspace}
+    end
+
+    test "writes skills and memory files under .claude/", %{workspace: workspace} do
+      tree = %{
+        files: %{
+          "CLAUDE.md" => "# Opal knowledge for apexphere/opal\n",
+          "skills/commit/SKILL.md" => "---\nname: commit\n---\n",
+          "memory/MEMORY.md" => "- [note](note.md)\n"
+        }
+      }
+
+      assert :ok = Knowledge.inject_tree(workspace, tree)
+
+      assert File.read!(Path.join(workspace, ".claude/opal-knowledge.md")) ==
+               "# Opal knowledge for apexphere/opal\n"
+
+      assert File.read!(Path.join(workspace, ".claude/skills/commit/SKILL.md")) ==
+               "---\nname: commit\n---\n"
+
+      assert File.read!(Path.join(workspace, ".claude/memory/MEMORY.md")) ==
+               "- [note](note.md)\n"
+    end
+
+    test "creates workspace CLAUDE.md with @-import when target has none", %{workspace: workspace} do
+      tree = %{files: %{"CLAUDE.md" => "body\n"}}
+
+      :ok = Knowledge.inject_tree(workspace, tree)
+
+      content = File.read!(Path.join(workspace, "CLAUDE.md"))
+      assert content =~ "@.claude/opal-knowledge.md"
+    end
+
+    test "preserves target-repo-native CLAUDE.md and appends import if missing",
+         %{workspace: workspace} do
+      File.write!(Path.join(workspace, "CLAUDE.md"), "# Target project rules\n")
+
+      :ok = Knowledge.inject_tree(workspace, %{files: %{"CLAUDE.md" => "body\n"}})
+
+      content = File.read!(Path.join(workspace, "CLAUDE.md"))
+      assert content =~ "# Target project rules"
+      assert content =~ "@.claude/opal-knowledge.md"
+    end
+
+    test "is idempotent — re-run does not duplicate import line", %{workspace: workspace} do
+      tree = %{files: %{"CLAUDE.md" => "body\n"}}
+
+      :ok = Knowledge.inject_tree(workspace, tree)
+      :ok = Knowledge.inject_tree(workspace, tree)
+
+      content = File.read!(Path.join(workspace, "CLAUDE.md"))
+      occurrences = Regex.scan(~r/@\.claude\/opal-knowledge\.md/, content) |> length()
+      assert occurrences == 1
+    end
+
+    test "empty tree produces no-op (no CLAUDE.md, no .claude dir polluted)",
+         %{workspace: workspace} do
+      :ok = Knowledge.inject_tree(workspace, %{files: %{}})
+
+      refute File.exists?(Path.join(workspace, "CLAUDE.md"))
+      refute File.exists?(Path.join(workspace, ".claude/opal-knowledge.md"))
+    end
+
+    test "treats tree without CLAUDE.md as skills-only injection", %{workspace: workspace} do
+      tree = %{
+        files: %{
+          "skills/push/SKILL.md" => "---\nname: push\n---\n"
+        }
+      }
+
+      :ok = Knowledge.inject_tree(workspace, tree)
+
+      assert File.read!(Path.join(workspace, ".claude/skills/push/SKILL.md")) =~ "name: push"
+      refute File.exists?(Path.join(workspace, "CLAUDE.md"))
+      refute File.exists?(Path.join(workspace, ".claude/opal-knowledge.md"))
+    end
+  end
+
+  describe "project_key_for/1" do
+    test "github kind returns owner_repo slug" do
+      tracker = %{kind: "github", repo: "apexphere/opal", project_slug: nil}
+      assert Knowledge.project_key_for(tracker) == "github_apexphere_opal"
+    end
+
+    test "linear kind returns linear_<slug>" do
+      tracker = %{kind: "linear", repo: nil, project_slug: "alpha"}
+      assert Knowledge.project_key_for(tracker) == "linear_alpha"
+    end
+
+    test "memory kind returns memory_<slug>" do
+      tracker = %{kind: "memory", repo: nil, project_slug: "test"}
+      assert Knowledge.project_key_for(tracker) == "memory_test"
+    end
+
+    test "github kind without repo returns github_unknown" do
+      tracker = %{kind: "github", repo: nil, project_slug: nil}
+      assert Knowledge.project_key_for(tracker) == "github_unknown"
+    end
+
+    test "sanitizes unsafe chars in slug" do
+      tracker = %{kind: "github", repo: "owner/repo with spaces", project_slug: nil}
+      assert Knowledge.project_key_for(tracker) == "github_owner_repo_with_spaces"
+    end
+  end
+end


### PR DESCRIPTION
Closes #14

#### Context

Opal is designed to be deployed to a VPS, assigned a target project, and compound competence on that project across many runs. Without a dedicated knowledge subsystem, every run starts cold — re-learning project conventions and re-hitting known gotchas.

#### TL;DR

*Opal now holds per-project CLAUDE.md + skills/ + memory/ trees outside the target repo and injects the active project's tree into the workspace before the coding agent spawns.*

#### Summary

- `feat(config)` — adds `knowledge.backend` + `knowledge.root` to `Config.Schema` with Ecto validation; default root resolves via `Knowledge.default_root/0`.
- `feat(knowledge)` — adds `Store` behaviour (`load`/`write`/`list_projects`) and a `Filesystem` backend with path-traversal guard; unknown projects load as an empty tree.
- `feat(knowledge)` — adds the `Knowledge` module: `inject/2`, `capture/3`, `load/1`, plus `project_key_for/1` derived from tracker config.
- `feat(workspace)` — wires `Knowledge.inject/2` into `Workspace.create_for_issue/2` after the after-create hook; remote SSH workers skip; injection failures degrade gracefully.
- `docs(knowledge)` — SPEC §9.6 defines the language-neutral injection contract; README lists the subsystem alongside other core components.
- `chore(knowledge)` — adds an example seed tree for `apexphere/opal-test-tracker` as reference material.
- `test(knowledge)` — closes coverage gaps (store-error branch, `load/1` delegation, unrecognized tracker kind, filesystem non-directory root).
- Injection writes the project's `CLAUDE.md` body to `<workspace>/.claude/opal-knowledge.md` and appends `@.claude/opal-knowledge.md` to the workspace's root `CLAUDE.md`; de-duplicated on re-run so it is idempotent.

#### Alternatives

- **Store knowledge inside the target repo's `.claude/`** — rejected: invasive for customer codebases and would be lost on a fresh clone. The whole point is that Opal owns this knowledge outside the target.
- **Load every project's knowledge into every run** — rejected: with N projects this overflows the context budget. The subsystem is keyed by `project_key` so only the active project's tree is injected.
- **Overwrite the target's existing `CLAUDE.md`** — rejected: the target's instructions must remain primary. Opal's content is surfaced via an appended `@-import` line instead.
- **Ship git-backed / Postgres / S3 backends now** — rejected as scope creep for the MVP; the `Store` behaviour is pluggable so these can layer on later without touching the Knowledge module.
- **Automated curator that proposes memory entries post-run** — deferred to Phase 2 per the issue; `capture/3` is manual-only for now.
- **Convenience `mix opal.knowledge.edit <project_key>` task** — deferred; can be added as a follow-up if the manual-edit UX turns out to hurt in practice.

#### Test Plan

- [x] `make -C elixir all` (format, credo --strict, dialyzer, 100% coverage gate)
- [x] Knowledge unit tests: `inject_tree/2` happy path, skills-only, target coexistence, idempotent re-run, empty-tree no-op, `project_key_for/1` edge cases (github/linear/memory/unrecognized/unsafe chars)
- [x] Filesystem store tests: `list_projects/1` (empty/populated/missing/non-directory root), `load/2` (unknown/populated), `write/4` (happy/`..`/absolute/idempotent overwrite)
- [x] Integration: `Workspace.create_for_issue/2` with seed → `.claude/` tree matches; empty project → no-op; target-native `CLAUDE.md` coexists with appended import; `Knowledge.capture/3` round-trip; store-error degrades to logged warning; `Knowledge.load/1` delegation
- [ ] Manual: verify behaviour on a real workspace after landing
