### PR TITLE
feat: self-verifying Phase 1 — recipe execution + tracker revert on fail

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -6,7 +6,7 @@ defmodule SymphonyElixir.AgentRunner do
   require Logger
   alias SymphonyElixir.ClaudeCode.Runner, as: ClaudeCodeRunner
   alias SymphonyElixir.Codex.AppServer
-  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
+  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Verification, Workspace}
 
   @type worker_host :: String.t() | nil
 
@@ -138,8 +138,8 @@ defmodule SymphonyElixir.AgentRunner do
 
           :ok
 
-        {:done, _refreshed_issue} ->
-          :ok
+        {:done, refreshed_issue} ->
+          handle_done(workspace, refreshed_issue)
 
         {:error, reason} ->
           {:error, reason}
@@ -183,13 +183,66 @@ defmodule SymphonyElixir.AgentRunner do
 
           :ok
 
-        {:done, _refreshed_issue} ->
-          :ok
+        {:done, refreshed_issue} ->
+          handle_done(workspace, refreshed_issue)
 
         {:error, reason} ->
           {:error, reason}
       end
     end
+  end
+
+  defp handle_done(workspace, issue) do
+    settings = Config.settings!().verification
+
+    if settings.enabled do
+      run_verification(workspace, issue)
+    else
+      :ok
+    end
+  end
+
+  defp run_verification(workspace, issue) do
+    settings = Config.settings!().verification
+    outcome = Verification.verify(workspace, settings)
+
+    Logger.info("Verification #{outcome.status} for #{issue_context(issue)} workspace=#{workspace} steps=#{length(outcome.steps)}")
+
+    case outcome.status do
+      :pass ->
+        :ok
+
+      :skipped ->
+        :ok
+
+      :fail ->
+        revert_issue_state(issue, outcome)
+        :ok
+    end
+  end
+
+  defp revert_issue_state(%Issue{id: issue_id}, outcome) when is_binary(issue_id) do
+    active_states = Config.settings!().tracker.active_states
+
+    case List.last(active_states) do
+      nil ->
+        Logger.warning("Verification failed for issue_id=#{issue_id} but no active_states configured; cannot revert")
+
+      target_state ->
+        case Tracker.update_issue_state(issue_id, target_state) do
+          :ok ->
+            Logger.info("Verification reverted issue_id=#{issue_id} to state=#{target_state} (failed steps=#{failed_step_count(outcome)})")
+
+          {:error, reason} ->
+            Logger.warning("Verification revert failed issue_id=#{issue_id} target_state=#{target_state} reason=#{inspect(reason)}")
+        end
+    end
+  end
+
+  defp revert_issue_state(_issue, _outcome), do: :ok
+
+  defp failed_step_count(%{steps: steps}) do
+    Enum.count(steps, fn step -> not step.passed end)
   end
 
   defp build_turn_prompt(issue, opts, 1, _max_turns), do: PromptBuilder.build_prompt(issue, opts)

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -318,6 +318,26 @@ defmodule SymphonyElixir.Config.Schema do
     end
   end
 
+  defmodule Verification do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field(:enabled, :boolean, default: false)
+      field(:required, :boolean, default: false)
+      field(:step_timeout_ms, :integer, default: 600_000)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(attrs, [:enabled, :required, :step_timeout_ms], empty_values: [])
+      |> validate_number(:step_timeout_ms, greater_than: 0)
+    end
+  end
+
   embedded_schema do
     embeds_one(:tracker, Tracker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:polling, Polling, on_replace: :update, defaults_to_struct: true)
@@ -330,6 +350,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:observability, Observability, on_replace: :update, defaults_to_struct: true)
     embeds_one(:server, Server, on_replace: :update, defaults_to_struct: true)
     embeds_one(:knowledge, Knowledge, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:verification, Verification, on_replace: :update, defaults_to_struct: true)
   end
 
   @spec parse(map()) :: {:ok, %__MODULE__{}} | {:error, {:invalid_workflow_config, String.t()}}
@@ -424,6 +445,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:observability, with: &Observability.changeset/2)
     |> cast_embed(:server, with: &Server.changeset/2)
     |> cast_embed(:knowledge, with: &Knowledge.changeset/2)
+    |> cast_embed(:verification, with: &Verification.changeset/2)
   end
 
   defp finalize_settings(settings) do

--- a/elixir/lib/symphony_elixir/verification.ex
+++ b/elixir/lib/symphony_elixir/verification.ex
@@ -1,0 +1,144 @@
+defmodule SymphonyElixir.Verification do
+  @moduledoc """
+  Self-verification — exercise the build the way a user would, before
+  treating an agent run as truly done.
+
+  Phase 1 contract:
+  * Recipe is read from `<workspace>/.opal/verify.json` (see
+    `SymphonyElixir.Verification.Recipe`). The agent emits the recipe as a
+    byproduct of building. Opal does not author it.
+  * Each step is executed sequentially via the configured executor (default
+    `Executor.Bash`). A step passes when its exit code matches `expect_exit`.
+  * The full execution log is persisted to `<workspace>/.opal/verify-log.json`.
+  * The result is `:pass`, `:fail`, or `:skipped` — Phase 1 has no
+    re-prompting loop. Phase 2 will feed failure evidence into the next
+    agent turn.
+
+  Behaviour is gated by `config.verification.enabled`. When the flag is off
+  this module is never called. When on but no recipe exists, behaviour
+  depends on `config.verification.required`:
+  * `required: false` (default) — skip with `:no_recipe` reason.
+  * `required: true`           — fail.
+  """
+
+  require Logger
+
+  alias SymphonyElixir.Verification.{Recipe, Result}
+
+  @log_rel_path ".opal/verify-log.json"
+
+  @type settings :: %{required(:required) => boolean(), required(:step_timeout_ms) => pos_integer()}
+  @type status :: :pass | :fail | :skipped
+  @type outcome :: %{
+          status: status(),
+          steps: [map()],
+          skipped_reason: term() | nil,
+          recipe: Recipe.t() | nil,
+          started_at: DateTime.t(),
+          finished_at: DateTime.t()
+        }
+
+  @spec verify(Path.t(), settings()) :: outcome()
+  def verify(workspace, settings) when is_binary(workspace) and is_map(settings) do
+    started_at = DateTime.utc_now()
+
+    outcome =
+      case Recipe.read(workspace) do
+        {:ok, recipe} ->
+          execute(recipe, workspace, settings, started_at)
+
+        {:error, :no_recipe} when settings.required ->
+          fail_outcome(:no_recipe, started_at)
+
+        {:error, :no_recipe} ->
+          skip_outcome(:no_recipe, started_at)
+
+        {:error, {:invalid_recipe, _} = reason} ->
+          fail_outcome(reason, started_at)
+      end
+
+    persist_log(workspace, outcome)
+    outcome
+  end
+
+  @spec log_rel_path() :: String.t()
+  def log_rel_path, do: @log_rel_path
+
+  defp execute(%Recipe{steps: steps} = recipe, workspace, settings, started_at) do
+    executor = executor_module()
+    timeout_ms = settings.step_timeout_ms
+
+    {step_results, status} =
+      Enum.reduce_while(steps, {[], :pass}, fn step, {acc, _status} ->
+        run = executor.run_step(step, workspace, timeout_ms: timeout_ms)
+        passed = run.exit == step.expect_exit
+
+        record =
+          %{
+            name: step.name,
+            shell: step.shell,
+            expect_exit: step.expect_exit,
+            exit: run.exit,
+            passed: passed,
+            output: run.output,
+            duration_ms: run.duration_ms
+          }
+
+        if passed do
+          {:cont, {[record | acc], :pass}}
+        else
+          {:halt, {[record | acc], :fail}}
+        end
+      end)
+
+    %{
+      status: status,
+      steps: Enum.reverse(step_results),
+      skipped_reason: nil,
+      recipe: recipe,
+      started_at: started_at,
+      finished_at: DateTime.utc_now()
+    }
+  end
+
+  defp skip_outcome(reason, started_at) do
+    %{
+      status: :skipped,
+      steps: [],
+      skipped_reason: reason,
+      recipe: nil,
+      started_at: started_at,
+      finished_at: DateTime.utc_now()
+    }
+  end
+
+  defp fail_outcome(reason, started_at) do
+    %{
+      status: :fail,
+      steps: [],
+      skipped_reason: reason,
+      recipe: nil,
+      started_at: started_at,
+      finished_at: DateTime.utc_now()
+    }
+  end
+
+  defp persist_log(workspace, outcome) do
+    log_path = Path.join(workspace, @log_rel_path)
+    File.mkdir_p!(Path.dirname(log_path))
+    File.write!(log_path, Result.encode(outcome))
+  rescue
+    error ->
+      Logger.warning("Verification log persist failed workspace=#{workspace} reason=#{inspect(error)}")
+
+      :ok
+  end
+
+  defp executor_module do
+    Application.get_env(
+      :symphony_elixir,
+      :verification_executor_module,
+      SymphonyElixir.Verification.Executor.Bash
+    )
+  end
+end

--- a/elixir/lib/symphony_elixir/verification/executor.ex
+++ b/elixir/lib/symphony_elixir/verification/executor.ex
@@ -1,0 +1,19 @@
+defmodule SymphonyElixir.Verification.Executor do
+  @moduledoc """
+  Behaviour for executing a single verification step inside a workspace.
+
+  The default implementation is `SymphonyElixir.Verification.Executor.Bash`,
+  which runs the step's `shell` via `bash -lc` with the workspace as cwd.
+  """
+
+  alias SymphonyElixir.Verification.Recipe.Step
+
+  @type result :: %{
+          exit: integer() | :timeout,
+          output: String.t(),
+          duration_ms: non_neg_integer()
+        }
+
+  @callback run_step(step :: Step.t(), workspace :: Path.t(), opts :: keyword()) ::
+              result()
+end

--- a/elixir/lib/symphony_elixir/verification/executor/bash.ex
+++ b/elixir/lib/symphony_elixir/verification/executor/bash.ex
@@ -1,0 +1,47 @@
+defmodule SymphonyElixir.Verification.Executor.Bash do
+  @moduledoc """
+  Default `SymphonyElixir.Verification.Executor` — runs the step's `shell`
+  via `bash -lc` with the workspace as cwd. stderr is folded into stdout for
+  Phase-1 logging simplicity.
+  """
+
+  @behaviour SymphonyElixir.Verification.Executor
+
+  alias SymphonyElixir.Verification.Recipe.Step
+
+  @impl true
+  @spec run_step(Step.t(), Path.t(), keyword()) ::
+          SymphonyElixir.Verification.Executor.result()
+  def run_step(%Step{shell: shell}, workspace, opts) do
+    timeout_ms = Keyword.get(opts, :timeout_ms, 600_000)
+    started_at = System.monotonic_time(:millisecond)
+
+    task =
+      Task.async(fn ->
+        System.cmd("bash", ["-lc", shell],
+          cd: workspace,
+          stderr_to_stdout: true
+        )
+      end)
+
+    case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, exit_code}} ->
+        %{
+          exit: exit_code,
+          output: output,
+          duration_ms: elapsed(started_at)
+        }
+
+      nil ->
+        %{
+          exit: :timeout,
+          output: "",
+          duration_ms: elapsed(started_at)
+        }
+    end
+  end
+
+  defp elapsed(started_at_ms) do
+    System.monotonic_time(:millisecond) - started_at_ms
+  end
+end

--- a/elixir/lib/symphony_elixir/verification/recipe.ex
+++ b/elixir/lib/symphony_elixir/verification/recipe.ex
@@ -1,0 +1,82 @@
+defmodule SymphonyElixir.Verification.Recipe do
+  @moduledoc """
+  Verification recipe — read from `<workspace>/.opal/verify.json`.
+
+  Schema (v1):
+
+      {
+        "version": "1",
+        "description": "Curl the new endpoint",
+        "steps": [
+          {"name": "ping", "shell": "curl -fsS http://localhost:4000", "expect_exit": 0}
+        ]
+      }
+
+  The agent that built the change emits the recipe as a byproduct of building —
+  Opal does not author it. Opal only loads, executes, and judges.
+  """
+
+  alias SymphonyElixir.Verification.Recipe.Step
+
+  @recipe_rel_path ".opal/verify.json"
+
+  @type t :: %__MODULE__{
+          description: String.t() | nil,
+          steps: [Step.t()]
+        }
+
+  defstruct [:description, steps: []]
+
+  @spec rel_path() :: String.t()
+  def rel_path, do: @recipe_rel_path
+
+  @spec read(Path.t()) ::
+          {:ok, t()} | {:error, :no_recipe} | {:error, {:invalid_recipe, term()}}
+  def read(workspace) when is_binary(workspace) do
+    path = Path.join(workspace, @recipe_rel_path)
+
+    case File.read(path) do
+      {:ok, content} -> parse(content)
+      {:error, :enoent} -> {:error, :no_recipe}
+      {:error, reason} -> {:error, {:invalid_recipe, {:read_failed, reason}}}
+    end
+  end
+
+  @spec parse(String.t()) :: {:ok, t()} | {:error, {:invalid_recipe, term()}}
+  def parse(content) when is_binary(content) do
+    with {:ok, data} <- decode_json(content),
+         :ok <- ensure_map(data),
+         {:ok, steps} <- parse_steps(Map.get(data, "steps")) do
+      {:ok, %__MODULE__{description: Map.get(data, "description"), steps: steps}}
+    end
+  end
+
+  defp decode_json(content) do
+    case Jason.decode(content) do
+      {:ok, value} -> {:ok, value}
+      {:error, reason} -> {:error, {:invalid_recipe, {:malformed_json, reason}}}
+    end
+  end
+
+  defp ensure_map(value) when is_map(value), do: :ok
+  defp ensure_map(_), do: {:error, {:invalid_recipe, :not_an_object}}
+
+  defp parse_steps(steps) when is_list(steps) and steps != [] do
+    steps
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, []}, fn {step, index}, {:ok, acc} ->
+      case Step.parse(step, index) do
+        {:ok, parsed} -> {:cont, {:ok, [parsed | acc]}}
+        {:error, reason} -> {:halt, {:error, {:invalid_recipe, {:step, index, reason}}}}
+      end
+    end)
+    |> case do
+      {:ok, parsed_reversed} -> {:ok, Enum.reverse(parsed_reversed)}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_steps(nil), do: {:error, {:invalid_recipe, :missing_steps}}
+  defp parse_steps([]), do: {:error, {:invalid_recipe, :empty_steps}}
+  defp parse_steps(_), do: {:error, {:invalid_recipe, :steps_not_a_list}}
+end

--- a/elixir/lib/symphony_elixir/verification/recipe/step.ex
+++ b/elixir/lib/symphony_elixir/verification/recipe/step.ex
@@ -1,0 +1,41 @@
+defmodule SymphonyElixir.Verification.Recipe.Step do
+  @moduledoc """
+  A single recipe step. Phase-1 supports a shell command and an expected exit code.
+  """
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          shell: String.t(),
+          expect_exit: integer()
+        }
+
+  defstruct [:name, :shell, expect_exit: 0]
+
+  @spec parse(map(), pos_integer()) :: {:ok, t()} | {:error, term()}
+  def parse(%{"shell" => shell} = step, index)
+      when is_binary(shell) and shell != "" do
+    {:ok,
+     %__MODULE__{
+       name: name(step, index),
+       shell: shell,
+       expect_exit: expect_exit(step)
+     }}
+  end
+
+  def parse(%{}, _index), do: {:error, :missing_shell}
+  def parse(_, _index), do: {:error, :not_an_object}
+
+  defp name(step, index) do
+    case Map.get(step, "name") do
+      name when is_binary(name) and name != "" -> name
+      _ -> "step_#{index}"
+    end
+  end
+
+  defp expect_exit(step) do
+    case Map.get(step, "expect_exit", 0) do
+      n when is_integer(n) -> n
+      _ -> 0
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/verification/result.ex
+++ b/elixir/lib/symphony_elixir/verification/result.ex
@@ -1,0 +1,55 @@
+defmodule SymphonyElixir.Verification.Result do
+  @moduledoc """
+  JSON encoding for the verification outcome persisted to
+  `<workspace>/.opal/verify-log.json`.
+  """
+
+  @spec encode(map()) :: String.t()
+  def encode(outcome) when is_map(outcome) do
+    outcome
+    |> to_payload()
+    |> Jason.encode_to_iodata!(pretty: true)
+    |> IO.iodata_to_binary()
+  end
+
+  defp to_payload(outcome) do
+    %{
+      "version" => "1",
+      "status" => Atom.to_string(outcome.status),
+      "started_at" => DateTime.to_iso8601(outcome.started_at),
+      "finished_at" => DateTime.to_iso8601(outcome.finished_at),
+      "duration_ms" => DateTime.diff(outcome.finished_at, outcome.started_at, :millisecond),
+      "skipped_reason" => encode_reason(outcome.skipped_reason),
+      "recipe" => encode_recipe(outcome.recipe),
+      "steps" => Enum.map(outcome.steps, &encode_step/1)
+    }
+  end
+
+  defp encode_step(step) do
+    %{
+      "name" => step.name,
+      "shell" => step.shell,
+      "expect_exit" => step.expect_exit,
+      "exit" => encode_exit(step.exit),
+      "passed" => step.passed,
+      "output" => step.output,
+      "duration_ms" => step.duration_ms
+    }
+  end
+
+  defp encode_recipe(nil), do: nil
+
+  defp encode_recipe(%SymphonyElixir.Verification.Recipe{} = recipe) do
+    %{
+      "description" => recipe.description,
+      "step_count" => length(recipe.steps)
+    }
+  end
+
+  defp encode_exit(:timeout), do: "timeout"
+  defp encode_exit(n) when is_integer(n), do: n
+
+  defp encode_reason(nil), do: nil
+  defp encode_reason(atom) when is_atom(atom), do: Atom.to_string(atom)
+  defp encode_reason(other), do: inspect(other)
+end

--- a/elixir/test/symphony_elixir/verification/recipe_test.exs
+++ b/elixir/test/symphony_elixir/verification/recipe_test.exs
@@ -4,6 +4,10 @@ defmodule SymphonyElixir.Verification.RecipeTest do
   alias SymphonyElixir.Verification.Recipe
   alias SymphonyElixir.Verification.Recipe.Step
 
+  test "rel_path points at .opal/verify.json" do
+    assert Recipe.rel_path() == ".opal/verify.json"
+  end
+
   describe "parse/1" do
     test "parses a single-step recipe with defaults" do
       json =
@@ -57,6 +61,21 @@ defmodule SymphonyElixir.Verification.RecipeTest do
       assert {:error, {:invalid_recipe, {:step, 1, :missing_shell}}} =
                Recipe.parse(Jason.encode!(%{"steps" => [%{"name" => "x"}]}))
     end
+
+    test "rejects non-object step entries" do
+      assert {:error, {:invalid_recipe, {:step, 1, :not_an_object}}} =
+               Recipe.parse(Jason.encode!(%{"steps" => [42]}))
+    end
+
+    test "rejects steps that are not a list" do
+      assert {:error, {:invalid_recipe, :steps_not_a_list}} =
+               Recipe.parse(Jason.encode!(%{"steps" => "nope"}))
+    end
+
+    test "falls back to expect_exit 0 when value is not an integer" do
+      json = Jason.encode!(%{"steps" => [%{"shell" => "true", "expect_exit" => "boom"}]})
+      assert {:ok, %Recipe{steps: [%Step{expect_exit: 0}]}} = Recipe.parse(json)
+    end
   end
 
   describe "read/1" do
@@ -82,6 +101,12 @@ defmodule SymphonyElixir.Verification.RecipeTest do
       )
 
       assert {:ok, %Recipe{steps: [%Step{name: "ping"}]}} = Recipe.read(workspace)
+    end
+
+    test "surfaces non-enoent read errors as invalid_recipe", %{workspace: workspace} do
+      File.write!(Path.join(workspace, ".opal"), "")
+
+      assert {:error, {:invalid_recipe, {:read_failed, _}}} = Recipe.read(workspace)
     end
   end
 end

--- a/elixir/test/symphony_elixir/verification/recipe_test.exs
+++ b/elixir/test/symphony_elixir/verification/recipe_test.exs
@@ -1,0 +1,87 @@
+defmodule SymphonyElixir.Verification.RecipeTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Verification.Recipe
+  alias SymphonyElixir.Verification.Recipe.Step
+
+  describe "parse/1" do
+    test "parses a single-step recipe with defaults" do
+      json =
+        Jason.encode!(%{
+          "version" => "1",
+          "description" => "Curl new endpoint",
+          "steps" => [%{"name" => "ping", "shell" => "curl -fsS http://localhost:4000"}]
+        })
+
+      assert {:ok, %Recipe{description: "Curl new endpoint", steps: [step]}} = Recipe.parse(json)
+      assert %Step{name: "ping", shell: "curl -fsS http://localhost:4000", expect_exit: 0} = step
+    end
+
+    test "parses multiple steps and respects expect_exit" do
+      json =
+        Jason.encode!(%{
+          "steps" => [
+            %{"name" => "first", "shell" => "true"},
+            %{"name" => "second", "shell" => "false", "expect_exit" => 1}
+          ]
+        })
+
+      assert {:ok, %Recipe{steps: [first, second]}} = Recipe.parse(json)
+      assert %Step{name: "first", expect_exit: 0} = first
+      assert %Step{name: "second", expect_exit: 1} = second
+    end
+
+    test "synthesizes a step name when missing" do
+      json = Jason.encode!(%{"steps" => [%{"shell" => "true"}]})
+      assert {:ok, %Recipe{steps: [%Step{name: "step_1"}]}} = Recipe.parse(json)
+    end
+
+    test "rejects malformed JSON" do
+      assert {:error, {:invalid_recipe, {:malformed_json, _}}} = Recipe.parse("not json")
+    end
+
+    test "rejects non-object payloads" do
+      assert {:error, {:invalid_recipe, :not_an_object}} = Recipe.parse(Jason.encode!([1, 2, 3]))
+    end
+
+    test "rejects missing steps" do
+      assert {:error, {:invalid_recipe, :missing_steps}} = Recipe.parse(Jason.encode!(%{}))
+    end
+
+    test "rejects empty steps" do
+      assert {:error, {:invalid_recipe, :empty_steps}} =
+               Recipe.parse(Jason.encode!(%{"steps" => []}))
+    end
+
+    test "rejects step missing shell" do
+      assert {:error, {:invalid_recipe, {:step, 1, :missing_shell}}} =
+               Recipe.parse(Jason.encode!(%{"steps" => [%{"name" => "x"}]}))
+    end
+  end
+
+  describe "read/1" do
+    setup do
+      workspace =
+        Path.join(System.tmp_dir!(), "opal-recipe-ws-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(workspace)
+      on_exit(fn -> File.rm_rf(workspace) end)
+      %{workspace: workspace}
+    end
+
+    test "returns :no_recipe when the file is absent", %{workspace: workspace} do
+      assert {:error, :no_recipe} = Recipe.read(workspace)
+    end
+
+    test "loads a recipe from .opal/verify.json", %{workspace: workspace} do
+      File.mkdir_p!(Path.join(workspace, ".opal"))
+
+      File.write!(
+        Path.join(workspace, ".opal/verify.json"),
+        Jason.encode!(%{"steps" => [%{"name" => "ping", "shell" => "true"}]})
+      )
+
+      assert {:ok, %Recipe{steps: [%Step{name: "ping"}]}} = Recipe.read(workspace)
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/verification_test.exs
+++ b/elixir/test/symphony_elixir/verification_test.exs
@@ -104,6 +104,21 @@ defmodule SymphonyElixir.VerificationTest do
     assert output =~ "hello"
   end
 
+  test "log_rel_path points at .opal/verify-log.json" do
+    assert Verification.log_rel_path() == ".opal/verify-log.json"
+  end
+
+  test "swallows persist-log failures so verification still returns an outcome",
+       %{workspace: workspace} do
+    File.write!(Path.join(workspace, ".opal"), "")
+
+    outcome = Verification.verify(workspace, settings())
+
+    assert outcome.status == :fail
+    assert {:invalid_recipe, {:read_failed, _}} = outcome.skipped_reason
+    refute File.exists?(Path.join(workspace, ".opal/verify-log.json"))
+  end
+
   test "uses a pluggable executor when configured", %{workspace: workspace} do
     defmodule FakeExecutor do
       @behaviour SymphonyElixir.Verification.Executor
@@ -125,5 +140,17 @@ defmodule SymphonyElixir.VerificationTest do
     assert outcome.status == :pass
     assert [%{name: "via-fake", output: "fake-output"}] = outcome.steps
     assert_received {:fake_executed, "via-fake"}
+  end
+
+  test "bash executor records :timeout exit when step exceeds timeout", %{workspace: workspace} do
+    write_recipe!(workspace, [%{"name" => "slow", "shell" => "sleep 2"}])
+
+    outcome = Verification.verify(workspace, settings(step_timeout_ms: 50))
+
+    assert outcome.status == :fail
+    assert [%{name: "slow", passed: false, exit: :timeout}] = outcome.steps
+
+    log = Path.join(workspace, ".opal/verify-log.json") |> File.read!() |> Jason.decode!()
+    assert [%{"exit" => "timeout"}] = log["steps"]
   end
 end

--- a/elixir/test/symphony_elixir/verification_test.exs
+++ b/elixir/test/symphony_elixir/verification_test.exs
@@ -1,0 +1,129 @@
+defmodule SymphonyElixir.VerificationTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.Verification
+
+  setup do
+    workspace =
+      Path.join(System.tmp_dir!(), "opal-verification-ws-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workspace)
+
+    on_exit(fn ->
+      File.rm_rf(workspace)
+      Application.delete_env(:symphony_elixir, :verification_executor_module)
+    end)
+
+    %{workspace: workspace}
+  end
+
+  defp settings(opts \\ []) do
+    %{
+      enabled: true,
+      required: Keyword.get(opts, :required, false),
+      step_timeout_ms: Keyword.get(opts, :step_timeout_ms, 5_000)
+    }
+  end
+
+  defp write_recipe!(workspace, steps, description \\ nil) do
+    File.mkdir_p!(Path.join(workspace, ".opal"))
+
+    payload =
+      %{"steps" => steps}
+      |> then(fn p -> if description, do: Map.put(p, "description", description), else: p end)
+
+    File.write!(Path.join(workspace, ".opal/verify.json"), Jason.encode!(payload))
+  end
+
+  test "passes when every step's exit matches expect_exit", %{workspace: workspace} do
+    write_recipe!(workspace, [%{"name" => "ok-step", "shell" => "true"}])
+
+    outcome = Verification.verify(workspace, settings())
+
+    assert outcome.status == :pass
+    assert [%{name: "ok-step", passed: true, exit: 0}] = outcome.steps
+    assert File.exists?(Path.join(workspace, ".opal/verify-log.json"))
+  end
+
+  test "fails on the first non-matching exit and stops executing further steps",
+       %{workspace: workspace} do
+    write_recipe!(workspace, [
+      %{"name" => "first-fails", "shell" => "exit 7"},
+      %{"name" => "should-not-run", "shell" => "echo nope"}
+    ])
+
+    outcome = Verification.verify(workspace, settings())
+
+    assert outcome.status == :fail
+    assert [%{name: "first-fails", passed: false, exit: 7}] = outcome.steps
+  end
+
+  test "honours expect_exit when the step is supposed to exit non-zero",
+       %{workspace: workspace} do
+    write_recipe!(workspace, [
+      %{"name" => "expect-1", "shell" => "exit 1", "expect_exit" => 1}
+    ])
+
+    assert %{status: :pass} = Verification.verify(workspace, settings())
+  end
+
+  test "skips with :no_recipe when no recipe file is present and required=false",
+       %{workspace: workspace} do
+    outcome = Verification.verify(workspace, settings(required: false))
+
+    assert outcome.status == :skipped
+    assert outcome.skipped_reason == :no_recipe
+  end
+
+  test "fails with :no_recipe when no recipe file is present and required=true",
+       %{workspace: workspace} do
+    outcome = Verification.verify(workspace, settings(required: true))
+
+    assert outcome.status == :fail
+    assert outcome.skipped_reason == :no_recipe
+  end
+
+  test "fails when the recipe file is malformed", %{workspace: workspace} do
+    File.mkdir_p!(Path.join(workspace, ".opal"))
+    File.write!(Path.join(workspace, ".opal/verify.json"), "not json")
+
+    outcome = Verification.verify(workspace, settings())
+
+    assert outcome.status == :fail
+    assert {:invalid_recipe, _} = outcome.skipped_reason
+  end
+
+  test "persists a JSON log capturing every step", %{workspace: workspace} do
+    write_recipe!(workspace, [%{"name" => "echo", "shell" => "echo hello"}])
+
+    Verification.verify(workspace, settings())
+
+    log = File.read!(Path.join(workspace, ".opal/verify-log.json")) |> Jason.decode!()
+    assert log["status"] == "pass"
+    assert [%{"name" => "echo", "output" => output, "passed" => true}] = log["steps"]
+    assert output =~ "hello"
+  end
+
+  test "uses a pluggable executor when configured", %{workspace: workspace} do
+    defmodule FakeExecutor do
+      @behaviour SymphonyElixir.Verification.Executor
+
+      alias SymphonyElixir.Verification.Recipe.Step
+
+      @impl true
+      def run_step(%Step{} = step, _workspace, _opts) do
+        send(self(), {:fake_executed, step.name})
+        %{exit: step.expect_exit, output: "fake-output", duration_ms: 1}
+      end
+    end
+
+    Application.put_env(:symphony_elixir, :verification_executor_module, FakeExecutor)
+    write_recipe!(workspace, [%{"name" => "via-fake", "shell" => "ignored"}])
+
+    outcome = Verification.verify(workspace, settings())
+
+    assert outcome.status == :pass
+    assert [%{name: "via-fake", output: "fake-output"}] = outcome.steps
+    assert_received {:fake_executed, "via-fake"}
+  end
+end

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1299,4 +1299,30 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       File.rm_rf(test_root)
     end
   end
+
+  test "schema parses verification config with custom values" do
+    assert {:ok, settings} =
+             Schema.parse(%{
+               verification: %{enabled: true, required: true, step_timeout_ms: 30_000}
+             })
+
+    assert settings.verification.enabled == true
+    assert settings.verification.required == true
+    assert settings.verification.step_timeout_ms == 30_000
+  end
+
+  test "schema defaults verification to disabled with 10-minute timeout" do
+    assert {:ok, settings} = Schema.parse(%{})
+
+    assert settings.verification.enabled == false
+    assert settings.verification.required == false
+    assert settings.verification.step_timeout_ms == 600_000
+  end
+
+  test "schema rejects non-positive verification step_timeout_ms" do
+    assert {:error, {:invalid_workflow_config, message}} =
+             Schema.parse(%{verification: %{step_timeout_ms: 0}})
+
+    assert message =~ "verification.step_timeout_ms"
+  end
 end


### PR DESCRIPTION
#### Context

First slice of #16 — the missing self-verifying pillar. Without a verification
step, an agent declaring "done" only means it exited; there is no evidence the
build works.

#### TL;DR

Run an agent-authored recipe (`.opal/verify.json`) after `{:done, _}`; revert
the tracker issue on failure. Default-off.

#### Summary

- `Verification.Recipe` reads and parses `<workspace>/.opal/verify.json` (v1 schema).
- `Verification.Executor` behaviour with default `Executor.Bash` (`bash -lc`, stderr→stdout, per-step timeout).
- `Verification.verify/2` orchestrates read → execute (halt on first fail) → persist `.opal/verify-log.json`.
- `AgentRunner.handle_done/2` invokes verification; on `:fail` reverts issue state via `Tracker.update_issue_state/2` so the orchestrator re-picks it up.
- New `config.verification` embed (`enabled`, `required`, `step_timeout_ms`). Default-off — existing deployments byte-identical until opted in.

#### Alternatives

- **Block tracker advance before `{:done, _}`** — cleaner but requires changing the agent-claims-done signal (agent writes a workspace artifact instead of touching the tracker). Much bigger architectural change; deferred.
- **Hardcoded verify commands in Opal config** — rejected: each project has a different "exercise it like a user" shape; the agent that built the change is the right author.
- **Bundle re-prompting + prompt instructions into this PR** — rejected to keep the runtime slice scoped; Phase 2 covers both.

#### Test Plan

- [x] `make -C elixir all` — 100% coverage, format+credo+dialyzer clean
- [x] `mix test test/symphony_elixir/verification_test.exs test/symphony_elixir/verification/recipe_test.exs` — all pass
- [ ] Manual smoke: enable `verification.enabled=true`, hand-author a `.opal/verify.json` in a workspace, observe revert on intentional fail

Not yet (Phase 2/3):
- No re-prompting loop — failure reverts state; next agent turn does not yet receive the log as continuation context.
- No `PromptBuilder` instructions telling the agent to emit `.opal/verify.json` — operators must instruct their agents themselves.
- No verifier-role separation — same agent emits and judges; Phase 3 adds a separate judge session.
