### PR TITLE
feat: self-verifying Phase 2a — prompt instructions for verify.json

### DIFF
--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -11,6 +11,36 @@ defmodule SymphonyElixir.PromptBuilder do
 
   @render_opts [strict_variables: true, strict_filters: true]
 
+  @verification_instruction """
+  ## Verification step (required before declaring done)
+
+  Before you mark this task as complete, write a verification recipe to
+  `.opal/verify.json` describing how to exercise the changes you made the way a
+  user would. Opal will execute every step and revert the issue to active if
+  any step fails.
+
+  Schema (v1):
+
+      {
+        "version": "1",
+        "description": "<one-line summary of what to exercise>",
+        "steps": [
+          {
+            "name": "<short step label>",
+            "shell": "<bash command run from the workspace root>",
+            "expect_exit": 0
+          }
+        ]
+      }
+
+  Each step's `shell` runs via `bash -lc` with the workspace as the working
+  directory. A step passes when its exit code matches `expect_exit` (default 0).
+  Steps run sequentially and stop on the first failure. Pick the smallest set
+  of steps that prove the user-visible behaviour you delivered actually works —
+  boot the thing, hit it the way a user would, check the response. Unit tests
+  are not enough.
+  """
+
   @spec build_prompt(SymphonyElixir.Linear.Issue.t(), keyword()) :: String.t()
   def build_prompt(issue, opts \\ []) do
     template =
@@ -21,16 +51,27 @@ defmodule SymphonyElixir.PromptBuilder do
     issue_map = issue |> Map.from_struct() |> to_solid_map()
     task_map = Map.put(issue_map, "number", Map.get(issue_map, "identifier"))
 
-    template
-    |> Solid.render!(
-      %{
-        "attempt" => Keyword.get(opts, :attempt),
-        "issue" => issue_map,
-        "task" => task_map
-      },
-      @render_opts
-    )
-    |> IO.iodata_to_binary()
+    rendered =
+      template
+      |> Solid.render!(
+        %{
+          "attempt" => Keyword.get(opts, :attempt),
+          "issue" => issue_map,
+          "task" => task_map
+        },
+        @render_opts
+      )
+      |> IO.iodata_to_binary()
+
+    append_verification_instruction(rendered)
+  end
+
+  defp append_verification_instruction(rendered) do
+    if Config.settings!().verification.enabled do
+      rendered <> "\n\n" <> @verification_instruction
+    else
+      rendered
+    end
   end
 
   defp prompt_template!({:ok, %{prompt_template: prompt}}), do: default_prompt(prompt)

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -135,6 +135,9 @@ defmodule SymphonyElixir.TestSupport do
           server_host: nil,
           knowledge_backend: nil,
           knowledge_root: nil,
+          verification_enabled: nil,
+          verification_required: nil,
+          verification_step_timeout_ms: nil,
           prompt: @workflow_prompt
         ],
         overrides
@@ -183,6 +186,9 @@ defmodule SymphonyElixir.TestSupport do
     server_host = Keyword.get(config, :server_host)
     knowledge_backend = Keyword.get(config, :knowledge_backend)
     knowledge_root = Keyword.get(config, :knowledge_root)
+    verification_enabled = Keyword.get(config, :verification_enabled)
+    verification_required = Keyword.get(config, :verification_required)
+    verification_step_timeout_ms = Keyword.get(config, :verification_step_timeout_ms)
     prompt = Keyword.get(config, :prompt)
 
     sections =
@@ -228,6 +234,7 @@ defmodule SymphonyElixir.TestSupport do
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),
         knowledge_yaml(knowledge_backend, knowledge_root),
+        verification_yaml(verification_enabled, verification_required, verification_step_timeout_ms),
         "---",
         prompt
       ]
@@ -319,6 +326,19 @@ defmodule SymphonyElixir.TestSupport do
       root && "  root: #{yaml_value(root)}"
     ]
     |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp verification_yaml(nil, nil, nil), do: nil
+
+  defp verification_yaml(enabled, required, step_timeout_ms) do
+    [
+      "verification:",
+      !is_nil(enabled) && "  enabled: #{yaml_value(enabled)}",
+      !is_nil(required) && "  required: #{yaml_value(required)}",
+      !is_nil(step_timeout_ms) && "  step_timeout_ms: #{yaml_value(step_timeout_ms)}"
+    ]
+    |> Enum.reject(&(&1 in [nil, false]))
     |> Enum.join("\n")
   end
 

--- a/elixir/test/symphony_elixir/prompt_builder_verification_test.exs
+++ b/elixir/test/symphony_elixir/prompt_builder_verification_test.exs
@@ -1,0 +1,48 @@
+defmodule SymphonyElixir.PromptBuilderVerificationTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Linear.Issue
+
+  @issue %Issue{
+    identifier: "MT-900",
+    title: "Add /healthz endpoint",
+    description: "Return 200 OK",
+    state: "Todo",
+    url: "https://example.org/issues/MT-900",
+    labels: []
+  }
+
+  test "appends the verification instruction when verification.enabled is true" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: true,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    assert prompt =~ "TASK MT-900"
+    assert prompt =~ "Verification step (required before declaring done)"
+    assert prompt =~ ".opal/verify.json"
+    assert prompt =~ "expect_exit"
+  end
+
+  test "omits the verification instruction when verification.enabled is false" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: false,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    assert prompt == "TASK MT-900"
+    refute prompt =~ "Verification step"
+  end
+
+  test "omits the verification instruction by default (verification block absent)" do
+    write_workflow_file!(Workflow.workflow_file_path(), prompt: "TASK {{ task.number }}")
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    refute prompt =~ "Verification step"
+  end
+end


### PR DESCRIPTION
#### Context

Phase 1 (#18) gave Opal the machinery to run a verification recipe but left
operators to instruct their agents themselves to write one. Without that
nudge, Phase 1 is a no-op.

#### TL;DR

Append a verification-recipe instruction to the rendered agent prompt when
`verification.enabled` is true.

#### Summary

- `PromptBuilder.build_prompt/2` appends an instruction block describing the v1 recipe schema when `config.verification.enabled` is true.
- Instruction framing: "boot the thing, hit it the way a user would; unit tests are not enough."
- Default-off: disabled `verification` leaves the prompt byte-identical to today.
- `write_workflow_file!/2` test helper gains `verification_enabled`, `verification_required`, `verification_step_timeout_ms` options so tests can drive the full config path.
- New `prompt_builder_verification_test.exs` covers enabled/disabled/default cases.

#### Alternatives

- **Put the instruction in a separate system prompt** — rejected: PromptBuilder is the single choke point for agent prompts; forking instructions across layers risks drift.
- **Always inject the block** — rejected: verification is off by default per #18, and the instructions would otherwise confuse agents on projects not yet opted in.
- **Make the instruction configurable per-project** — deferred: Phase 2b (continuation loop) will need agent-facing text anyway; keeping the copy in one place until shape settles.

#### Test Plan

- [x] `make -C elixir all` — 100% coverage, format+credo+dialyzer clean
- [x] `mix test test/symphony_elixir/prompt_builder_verification_test.exs` — 3/3 pass
