### PR TITLE
feat(verification): feed prior-verification failure back into turn-1 prompt (Phase 2b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,16 @@ alternative instead.
 
 When discussing "testing," default to user-perspective verification (use the thing the way it was
 built to be used), not just unit tests — see VISION.md for the reasoning.
+
+## Prefer agent teams for non-trivial work
+
+Opal's own self-verifying pillar is a bet on agents collaborating to ship real features. Model
+that here: for anything bigger than a small edit, reach for specialized subagents instead of
+doing it all in the lead session. Use Plan to design before implementing, Explore (thorough)
+when the codebase question spans more than a couple of files, and dev+QA teams to build and
+verify end-to-end. Parallelize independent work in a single turn.
+
+The lead session's job is to frame the problem, decide scope, integrate the outputs, and
+keep the vision in view. It is *not* to grind through implementation details that a teammate
+can do faster and in parallel. If a task is sequential and trivial, do it inline; otherwise,
+brief teammates with enough context that they can make judgement calls, and let them run.

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -108,7 +108,7 @@ defmodule SymphonyElixir.AgentRunner do
   end
 
   defp do_run_claude_code_turns(workspace, issue, codex_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do
-    prompt = build_turn_prompt(issue, opts, turn_number, max_turns)
+    prompt = build_turn_prompt(issue, opts, workspace, turn_number, max_turns)
 
     with {:ok, turn_result} <-
            claude_code_runner_module().run_turn(
@@ -152,7 +152,7 @@ defmodule SymphonyElixir.AgentRunner do
   end
 
   defp do_run_codex_turns(app_session, workspace, issue, codex_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do
-    prompt = build_turn_prompt(issue, opts, turn_number, max_turns)
+    prompt = build_turn_prompt(issue, opts, workspace, turn_number, max_turns)
 
     with {:ok, turn_session} <-
            AppServer.run_turn(
@@ -192,9 +192,10 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp build_turn_prompt(issue, opts, 1, _max_turns), do: PromptBuilder.build_prompt(issue, opts)
+  defp build_turn_prompt(issue, opts, workspace, 1, _max_turns),
+    do: PromptBuilder.build_prompt(issue, Keyword.put(opts, :workspace, workspace))
 
-  defp build_turn_prompt(_issue, _opts, turn_number, max_turns) do
+  defp build_turn_prompt(_issue, _opts, _workspace, turn_number, max_turns) do
     """
     Continuation guidance:
 

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -8,6 +8,7 @@ defmodule SymphonyElixir.PromptBuilder do
   """
 
   alias SymphonyElixir.{Config, Workflow}
+  alias SymphonyElixir.Verification.Feedback
 
   @render_opts [strict_variables: true, strict_filters: true]
 
@@ -83,12 +84,25 @@ defmodule SymphonyElixir.PromptBuilder do
       )
       |> IO.iodata_to_binary()
 
-    append_verification_instruction(rendered)
+    rendered
+    |> append_verification_instruction()
+    |> append_verification_feedback(Keyword.get(opts, :workspace))
   end
 
   defp append_verification_instruction(rendered) do
     if Config.settings!().verification.enabled do
       rendered <> "\n\n" <> @verification_instruction
+    else
+      rendered
+    end
+  end
+
+  defp append_verification_feedback(rendered, workspace) do
+    if Config.settings!().verification.enabled do
+      case Feedback.render(workspace) do
+        {:ok, block} -> rendered <> "\n\n" <> block
+        :none -> rendered
+      end
     else
       rendered
     end

--- a/elixir/lib/symphony_elixir/verification/feedback.ex
+++ b/elixir/lib/symphony_elixir/verification/feedback.ex
@@ -1,0 +1,102 @@
+defmodule SymphonyElixir.Verification.Feedback do
+  @moduledoc """
+  Render a continuation-prompt block from `<workspace>/.opal/verify-log.json`
+  when the previous verification run failed. The block is fed back into the
+  next agent turn so the agent sees the prior failure and diagnoses it instead
+  of blindly retrying. Non-fail outcomes, missing logs, and corrupt logs all
+  collapse to `:none` (corruption is logged so the operator notices).
+  """
+
+  require Logger
+
+  alias SymphonyElixir.Verification
+
+  @output_tail_limit 4 * 1024
+
+  @spec render(Path.t() | nil) :: {:ok, String.t()} | :none
+  def render(nil), do: :none
+
+  def render(workspace) when is_binary(workspace) do
+    path = Path.join(workspace, Verification.log_rel_path())
+
+    with {:ok, content} <- read_log(path),
+         {:ok, data} <- decode_log(content, path) do
+      render_from_payload(data)
+    end
+  end
+
+  defp read_log(path) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, content}
+      {:error, :enoent} -> :none
+    end
+  end
+
+  defp decode_log(content, path) do
+    case Jason.decode(content) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, reason} ->
+        Logger.warning("Verification feedback skipped: corrupt log path=#{path} reason=#{inspect(reason)}")
+        :none
+    end
+  end
+
+  defp render_from_payload(%{"status" => "fail"} = data) do
+    {:ok, build_block(data)}
+  end
+
+  defp render_from_payload(_other), do: :none
+
+  defp build_block(%{"steps" => [_ | _] = steps} = _data) do
+    step = Enum.find(steps, fn s -> Map.get(s, "passed") == false end)
+
+    """
+    ## Previous verification failed
+
+    Opal ran your `.opal/verify.json` after the last turn and it did not pass.
+    Diagnose the root cause below before making another attempt; do not simply
+    re-run the same steps.
+
+    - Failed step: #{Map.fetch!(step, "name")}
+    - Command: `#{Map.fetch!(step, "shell")}`
+    - Expected exit: #{Map.fetch!(step, "expect_exit")} | Actual exit: #{Map.fetch!(step, "exit")}
+    - Duration: #{Map.fetch!(step, "duration_ms")}ms
+
+    Captured output (tail):
+
+    ```
+    #{truncate_output(Map.fetch!(step, "output"))}
+    ```
+
+    Full log: `.opal/verify-log.json`.
+    """
+  end
+
+  defp build_block(%{"steps" => []} = data) do
+    """
+    ## Previous verification failed
+
+    Opal ran your `.opal/verify.json` after the last turn and it did not pass.
+    Diagnose the root cause below before making another attempt; do not simply
+    re-run the same steps.
+
+    The recipe could not be executed: #{Map.fetch!(data, "skipped_reason")}.
+
+    Full log: `.opal/verify-log.json`.
+    """
+  end
+
+  defp truncate_output(output) when is_binary(output) do
+    size = byte_size(output)
+
+    if size > @output_tail_limit do
+      omitted = size - @output_tail_limit
+      tail = binary_part(output, size - @output_tail_limit, @output_tail_limit)
+      "... (output truncated, #{omitted} bytes omitted; see .opal/verify-log.json) ...\n" <> tail
+    else
+      output
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/prompt_builder_feedback_test.exs
+++ b/elixir/test/symphony_elixir/prompt_builder_feedback_test.exs
@@ -1,0 +1,96 @@
+defmodule SymphonyElixir.PromptBuilderFeedbackTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Linear.Issue
+
+  @issue %Issue{
+    identifier: "MT-901",
+    title: "Add /healthz endpoint",
+    description: "Return 200 OK",
+    state: "Todo",
+    url: "https://example.org/issues/MT-901",
+    labels: []
+  }
+
+  defp fail_log do
+    Jason.encode!(%{
+      "version" => "1",
+      "status" => "fail",
+      "steps" => [
+        %{
+          "name" => "curl-healthz",
+          "shell" => "curl -fsS http://localhost:4000/healthz",
+          "expect_exit" => 0,
+          "exit" => 7,
+          "passed" => false,
+          "output" => "curl: (7) connection refused",
+          "duration_ms" => 12
+        }
+      ]
+    })
+  end
+
+  defp stage_log!(workspace, content) do
+    File.mkdir_p!(Path.join(workspace, ".opal"))
+    File.write!(Path.join([workspace, ".opal", "verify-log.json"]), content)
+  end
+
+  setup do
+    workspace =
+      Path.join(System.tmp_dir!(), "opal-prompt-fb-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workspace)
+    on_exit(fn -> File.rm_rf(workspace) end)
+    %{workspace: workspace}
+  end
+
+  test "omits the feedback block when verification.enabled is true but no workspace is given",
+       %{workspace: workspace} do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: true,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    stage_log!(workspace, fail_log())
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    refute prompt =~ "Previous verification failed"
+  end
+
+  test "appends the feedback block after the recipe instruction when a prior run failed",
+       %{workspace: workspace} do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: true,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    stage_log!(workspace, fail_log())
+
+    prompt = PromptBuilder.build_prompt(@issue, workspace: workspace)
+
+    assert prompt =~ "TASK MT-901"
+
+    instruction_index = :binary.match(prompt, "Verification step (required before declaring done)") |> elem(0)
+    feedback_index = :binary.match(prompt, "Previous verification failed") |> elem(0)
+    assert feedback_index > instruction_index
+
+    assert prompt =~ "curl-healthz"
+    assert prompt =~ "curl: (7) connection refused"
+  end
+
+  test "omits the feedback block when verification.enabled is false, even with a fail log",
+       %{workspace: workspace} do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: false,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    stage_log!(workspace, fail_log())
+
+    prompt = PromptBuilder.build_prompt(@issue, workspace: workspace)
+
+    assert prompt == "TASK MT-901"
+    refute prompt =~ "Previous verification failed"
+  end
+end

--- a/elixir/test/symphony_elixir/verification/feedback_test.exs
+++ b/elixir/test/symphony_elixir/verification/feedback_test.exs
@@ -1,0 +1,152 @@
+defmodule SymphonyElixir.Verification.FeedbackTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias SymphonyElixir.Verification.Feedback
+
+  setup do
+    workspace =
+      Path.join(System.tmp_dir!(), "opal-feedback-ws-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workspace)
+    on_exit(fn -> File.rm_rf(workspace) end)
+    %{workspace: workspace}
+  end
+
+  test "returns :none when workspace is nil" do
+    assert Feedback.render(nil) == :none
+  end
+
+  test "returns :none when the log file is missing", %{workspace: workspace} do
+    assert Feedback.render(workspace) == :none
+  end
+
+  test "returns :none when status is pass", %{workspace: workspace} do
+    write_log!(workspace, %{"status" => "pass", "steps" => []})
+
+    assert Feedback.render(workspace) == :none
+  end
+
+  test "returns :none when status is skipped", %{workspace: workspace} do
+    write_log!(workspace, %{"status" => "skipped", "steps" => [], "skipped_reason" => "no_recipe"})
+
+    assert Feedback.render(workspace) == :none
+  end
+
+  test "returns :none and logs a warning when the log is corrupt", %{workspace: workspace} do
+    write_log_raw!(workspace, "{not json")
+
+    log =
+      capture_log(fn ->
+        assert Feedback.render(workspace) == :none
+      end)
+
+    assert log =~ "Verification feedback skipped: corrupt log"
+  end
+
+  test "renders a failure block with step details", %{workspace: workspace} do
+    write_log!(workspace, %{
+      "status" => "fail",
+      "steps" => [
+        %{
+          "name" => "curl healthz",
+          "shell" => "curl -fsS http://localhost:4000/healthz",
+          "expect_exit" => 0,
+          "exit" => 7,
+          "passed" => false,
+          "output" => "connection refused",
+          "duration_ms" => 42
+        }
+      ]
+    })
+
+    assert {:ok, block} = Feedback.render(workspace)
+    assert block =~ "## Previous verification failed"
+    assert block =~ "Failed step: curl healthz"
+    assert block =~ "Command: `curl -fsS http://localhost:4000/healthz`"
+    assert block =~ "Expected exit: 0 | Actual exit: 7"
+    assert block =~ "Duration: 42ms"
+    assert block =~ "connection refused"
+    refute block =~ "output truncated"
+  end
+
+  test "renders a recipe-invalid block when steps list is empty", %{workspace: workspace} do
+    write_log!(workspace, %{
+      "status" => "fail",
+      "steps" => [],
+      "skipped_reason" => "no_recipe"
+    })
+
+    assert {:ok, block} = Feedback.render(workspace)
+    assert block =~ "The recipe could not be executed: no_recipe."
+    refute block =~ "Failed step:"
+    refute block =~ "Captured output"
+  end
+
+  test "renders a failure block when actual exit is the timeout string", %{workspace: workspace} do
+    write_log!(workspace, %{
+      "status" => "fail",
+      "steps" => [
+        %{
+          "name" => "boot server",
+          "shell" => "mix phx.server",
+          "expect_exit" => 0,
+          "exit" => "timeout",
+          "passed" => false,
+          "output" => "still booting...",
+          "duration_ms" => 60_000
+        }
+      ]
+    })
+
+    assert {:ok, block} = Feedback.render(workspace)
+    assert block =~ "Actual exit: timeout"
+  end
+
+  test "truncates output that exceeds 4 KB and reports the omitted bytes", %{workspace: workspace} do
+    output = String.duplicate("x", 5000)
+    omitted = 5000 - 4 * 1024
+
+    write_log!(workspace, %{
+      "status" => "fail",
+      "steps" => [
+        %{
+          "name" => "noisy step",
+          "shell" => "./noisy",
+          "expect_exit" => 0,
+          "exit" => 1,
+          "passed" => false,
+          "output" => output,
+          "duration_ms" => 10
+        }
+      ]
+    })
+
+    assert {:ok, block} = Feedback.render(workspace)
+    assert block =~ "... (output truncated, #{omitted} bytes omitted; see .opal/verify-log.json) ..."
+
+    captured = extract_captured_output(block)
+    assert byte_size(captured) <= 4 * 1024
+  end
+
+  defp write_log!(workspace, payload) do
+    write_log_raw!(workspace, Jason.encode!(payload))
+  end
+
+  defp write_log_raw!(workspace, content) do
+    opal_dir = Path.join(workspace, ".opal")
+    File.mkdir_p!(opal_dir)
+    File.write!(Path.join(opal_dir, "verify-log.json"), content)
+  end
+
+  defp extract_captured_output(block) do
+    [_, after_open] = String.split(block, "Captured output (tail):\n\n```\n", parts: 2)
+    [captured, _] = String.split(after_open, "\n```\n", parts: 2)
+
+    case String.split(captured, "\n", parts: 2) do
+      ["... (output truncated" <> _, rest] -> rest
+      [single] -> single
+    end
+  end
+end


### PR DESCRIPTION
#### Context

Phase 2b of the self-verifying pillar (#16). On verification failure Opal already reverts the issue so the orchestrator re-picks it — but the next agent turn had no memory of *why* it came back and would happily re-run the same broken recipe.

#### TL;DR

Feed prior-run `verify-log.json` back into the next turn-1 prompt so the agent can see what failed before retrying.

#### Summary

- New `SymphonyElixir.Verification.Feedback` reads `<workspace>/.opal/verify-log.json` and renders a continuation block (failed step, expected vs actual exit, duration, 4 KB-truncated output excerpt). Non-fail / missing / corrupt logs collapse to `:none`; corruption is logged.
- `PromptBuilder.build_prompt/2` threads `opts[:workspace]` and appends the feedback block after the Phase 2a recipe instruction, so the agent sees both contract and evidence. Call sites without `:workspace` (legacy tests) unaffected.
- `AgentRunner.build_turn_prompt/5` forwards the workspace it already has. Turn 2+ within a single run still uses the hardcoded continuation block; verification + feedback fire only on the orchestrator's re-pick after a revert.
- Gated on existing `config.verification.enabled` — no new flag. Closes part of #16.

#### Alternatives

- Add a separate `feedback_enabled` flag: rejected — a knob no user sensibly turns off alone would just re-introduce the silent-revert gap this phase closes.
- Inline the failed-step summary into the continuation prompt (no separate module): rejected — Feedback owns log parsing + truncation + corruption handling, worth its own module for testability.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix format --check-formatted` + `mix credo --strict` clean
- [x] Unit: `verification/feedback_test.exs` 9 cases (fail/pass/skipped/missing/corrupt/empty-steps/timeout-exit/4KB-truncation)
- [x] Integration: `prompt_builder_feedback_test.exs` 3 cases (block after instruction, omitted without workspace opt, omitted when disabled)
- [x] Live E2E 7/7 against real Config/WorkflowStore/PromptBuilder/Feedback path with a real verify-log.json on disk
- [ ] Not yet exercised against a live Linear/GitHub tracker end-to-end; orchestrator revert → re-pick covered in pieces (Phase 1 tests in #18 + this E2E), not as one live run