### PR TITLE
feat(dashboard): add GET /healthz liveness endpoint

### DIFF
--- a/.opal/healthz_server.exs
+++ b/.opal/healthz_server.exs
@@ -1,0 +1,23 @@
+for app <- [:bandit, :phoenix, :phoenix_html, :phoenix_live_view] do
+  Application.ensure_all_started(app)
+end
+
+{:ok, _} =
+  Supervisor.start_link(
+    [{Phoenix.PubSub, name: SymphonyElixir.PubSub}],
+    strategy: :one_for_one
+  )
+
+Application.put_env(:symphony_elixir, SymphonyElixirWeb.Endpoint,
+  server: true,
+  http: [ip: {127, 0, 0, 1}, port: 41_777],
+  url: [host: "localhost"],
+  secret_key_base: String.duplicate("s", 64),
+  check_origin: false,
+  pubsub_server: SymphonyElixir.PubSub,
+  live_view: [signing_salt: "opal-verify"]
+)
+
+{:ok, _} = SymphonyElixirWeb.Endpoint.start_link()
+
+Process.sleep(:infinity)

--- a/.opal/verify.json
+++ b/.opal/verify.json
@@ -1,0 +1,36 @@
+{
+  "version": "1",
+  "description": "Boot Phoenix endpoint and verify GET /healthz returns {\"status\":\"ok\"} with Content-Type application/json",
+  "steps": [
+    {
+      "name": "compile",
+      "shell": "cd elixir && MIX_ENV=test mix compile 2>&1",
+      "expect_exit": 0
+    },
+    {
+      "name": "start-server",
+      "shell": "cd elixir && MIX_ENV=test nohup mix run --no-start ../.opal/healthz_server.exs > /tmp/opal_healthz.log 2>&1 & SERVER_PID=$!; disown $SERVER_PID; echo $SERVER_PID > /tmp/opal_healthz_pid.txt; for i in $(seq 1 30); do curl -fs http://localhost:41777/healthz > /dev/null 2>&1 && exit 0; sleep 1; done; cat /tmp/opal_healthz.log >&2; exit 1",
+      "expect_exit": 0
+    },
+    {
+      "name": "curl-healthz",
+      "shell": "curl -fsS http://localhost:41777/healthz",
+      "expect_exit": 0
+    },
+    {
+      "name": "check-json",
+      "shell": "curl -s http://localhost:41777/healthz | grep -F '{\"status\":\"ok\"}'",
+      "expect_exit": 0
+    },
+    {
+      "name": "check-content-type",
+      "shell": "curl -sI http://localhost:41777/healthz | grep -i 'content-type' | grep -i 'application/json'",
+      "expect_exit": 0
+    },
+    {
+      "name": "stop-server",
+      "shell": "kill $(cat /tmp/opal_healthz_pid.txt) 2>/dev/null; true",
+      "expect_exit": 0
+    }
+  ]
+}

--- a/elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
+++ b/elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
@@ -8,6 +8,11 @@ defmodule SymphonyElixirWeb.ObservabilityApiController do
   alias Plug.Conn
   alias SymphonyElixirWeb.{Endpoint, Presenter}
 
+  @spec healthz(Conn.t(), map()) :: Conn.t()
+  def healthz(conn, _params) do
+    json(conn, %{status: "ok"})
+  end
+
   @spec state(Conn.t(), map()) :: Conn.t()
   def state(conn, _params) do
     json(conn, Presenter.state_payload(orchestrator(), snapshot_timeout_ms()))

--- a/elixir/lib/symphony_elixir_web/router.ex
+++ b/elixir/lib/symphony_elixir_web/router.ex
@@ -28,6 +28,8 @@ defmodule SymphonyElixirWeb.Router do
   end
 
   scope "/", SymphonyElixirWeb do
+    get("/healthz", ObservabilityApiController, :healthz)
+
     get("/api/v1/state", ObservabilityApiController, :state)
 
     match(:*, "/", ObservabilityApiController, :method_not_allowed)


### PR DESCRIPTION
## Summary

- Adds `GET /healthz` to the Phoenix observability router returning `200 OK` with `{"status":"ok"}` and `Content-Type: application/json`
- No auth required — consistent with existing `/api/v1/state` and sibling routes
- Verification recipe (`.opal/verify.json`) compiles the project, boots the endpoint, and curls `/healthz` to prove the user-visible behaviour end-to-end

## Test plan

- [ ] `curl -fsS http://localhost:4000/healthz` exits 0
- [ ] Response body is `{"status":"ok"}`
- [ ] `Content-Type` header contains `application/json`
- [ ] Existing routes (`/api/v1/state`, `/api/v1/refresh`, etc.) unaffected
- [ ] Opal verification recipe passes (boots server, hits endpoint, checks body + header)

Closes #21