### PR TITLE
feat(verification): forbid unit-test recipes and .opal/ commits

### DIFF
--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -37,8 +37,28 @@ defmodule SymphonyElixir.PromptBuilder do
   directory. A step passes when its exit code matches `expect_exit` (default 0).
   Steps run sequentially and stop on the first failure. Pick the smallest set
   of steps that prove the user-visible behaviour you delivered actually works —
-  boot the thing, hit it the way a user would, check the response. Unit tests
-  are not enough.
+  boot the thing, hit it the way a user would, check the response.
+
+  ### Recipe steps MUST exercise the delivered interface, not run unit tests
+
+  A step whose `shell` invokes a language test runner (for example `mix test`,
+  `pytest`, `go test`, `npm test`, `cargo test`, `rspec`) is NOT a valid recipe
+  step. Unit tests against code you just wrote prove only internal consistency;
+  the recipe must prove the change works from the outside. If you delivered an
+  HTTP endpoint, the step is a `curl` or equivalent against a running server;
+  if you delivered a CLI flag, the step invokes the CLI with that flag; if you
+  delivered a module function with no user-facing surface, the step is a short
+  `elixir`/`python`/`node` one-liner that calls it and prints an assertion. You
+  may still run unit tests separately as a sanity check — just not as the
+  recipe.
+
+  ### `.opal/` is workspace-only — never commit it
+
+  Write `.opal/verify.json` (and any other files under `.opal/`) to the
+  workspace, but do NOT `git add` them, do NOT stage them, and do NOT let them
+  reach the target repository. They are Opal scratch, not project code. If you
+  use `git add -A` or `git commit -a`, check the staged list and unstage
+  anything under `.opal/` before committing.
   """
 
   @spec build_prompt(SymphonyElixir.Linear.Issue.t(), keyword()) :: String.t()

--- a/elixir/test/symphony_elixir/prompt_builder_verification_test.exs
+++ b/elixir/test/symphony_elixir/prompt_builder_verification_test.exs
@@ -26,6 +26,33 @@ defmodule SymphonyElixir.PromptBuilderVerificationTest do
     assert prompt =~ "expect_exit"
   end
 
+  test "verification instruction forbids language test runners as recipe steps" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: true,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    assert prompt =~ "Recipe steps MUST exercise the delivered interface"
+    assert prompt =~ "mix test"
+    assert prompt =~ "pytest"
+    assert prompt =~ "go test"
+    assert prompt =~ "npm test"
+  end
+
+  test "verification instruction warns that .opal/ is workspace-only" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      verification_enabled: true,
+      prompt: "TASK {{ task.number }}"
+    )
+
+    prompt = PromptBuilder.build_prompt(@issue)
+
+    assert prompt =~ "`.opal/` is workspace-only"
+    assert prompt =~ "never commit"
+  end
+
   test "omits the verification instruction when verification.enabled is false" do
     write_workflow_file!(Workflow.workflow_file_path(),
       verification_enabled: false,


### PR DESCRIPTION
#### Context

Adversarial dogfood (#24 → #27) walked straight through the existing "Unit tests are not enough" line: the agent shipped `mix test` as the verify recipe (F4) and committed `.opal/verify.json` to main (F3). Soft guidance wasn't load-bearing enough.

#### TL;DR

Harden `@verification_instruction` to enumerate forbidden recipe shells and forbid committing `.opal/`.

#### Summary

- Forbidden recipe shells now enumerated: `mix test`, `pytest`, `go test`, `npm test`, `cargo test`, `rspec` — with the right shape per interface type (HTTP → curl, CLI → invoke the CLI, pure function → one-liner that calls + asserts).
- `.opal/` declared workspace-only: do not `git add`, do not stage, do not commit. Audit staged list if `git add -A` was used.
- Two new tests asserting both new guardrail blocks appear when verification is enabled.

#### Alternatives

- Recipe linter (pre-flight check that rejects `/mix test|pytest|.../` shells): defer to Phase 3 — prompt-layer fix unblocks immediately, linter is the structural follow-up.
- Verifier-role separation (Phase 3 of self-verifying plan): correct long-term answer but big scope; this PR is the short-term load-bearing fix.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix test test/symphony_elixir/prompt_builder_verification_test.exs` — 5/5 pass
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [ ] Next dogfood run: verify the recipe contains no language test runner and no `.opal/` file lands in the target commit