### PR TITLE
fix(orchestrator): verify before advancing on terminal tracker state (#30)

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -6,7 +6,7 @@ defmodule SymphonyElixir.AgentRunner do
   require Logger
   alias SymphonyElixir.ClaudeCode.Runner, as: ClaudeCodeRunner
   alias SymphonyElixir.Codex.AppServer
-  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Verification, Workspace}
+  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
 
   @type worker_host :: String.t() | nil
 
@@ -138,8 +138,8 @@ defmodule SymphonyElixir.AgentRunner do
 
           :ok
 
-        {:done, refreshed_issue} ->
-          handle_done(workspace, refreshed_issue)
+        {:done, _refreshed_issue} ->
+          :ok
 
         {:error, reason} ->
           {:error, reason}
@@ -183,66 +183,13 @@ defmodule SymphonyElixir.AgentRunner do
 
           :ok
 
-        {:done, refreshed_issue} ->
-          handle_done(workspace, refreshed_issue)
+        {:done, _refreshed_issue} ->
+          :ok
 
         {:error, reason} ->
           {:error, reason}
       end
     end
-  end
-
-  defp handle_done(workspace, issue) do
-    settings = Config.settings!().verification
-
-    if settings.enabled do
-      run_verification(workspace, issue)
-    else
-      :ok
-    end
-  end
-
-  defp run_verification(workspace, issue) do
-    settings = Config.settings!().verification
-    outcome = Verification.verify(workspace, settings)
-
-    Logger.info("Verification #{outcome.status} for #{issue_context(issue)} workspace=#{workspace} steps=#{length(outcome.steps)}")
-
-    case outcome.status do
-      :pass ->
-        :ok
-
-      :skipped ->
-        :ok
-
-      :fail ->
-        revert_issue_state(issue, outcome)
-        :ok
-    end
-  end
-
-  defp revert_issue_state(%Issue{id: issue_id}, outcome) when is_binary(issue_id) do
-    active_states = Config.settings!().tracker.active_states
-
-    case List.last(active_states) do
-      nil ->
-        Logger.warning("Verification failed for issue_id=#{issue_id} but no active_states configured; cannot revert")
-
-      target_state ->
-        case Tracker.update_issue_state(issue_id, target_state) do
-          :ok ->
-            Logger.info("Verification reverted issue_id=#{issue_id} to state=#{target_state} (failed steps=#{failed_step_count(outcome)})")
-
-          {:error, reason} ->
-            Logger.warning("Verification revert failed issue_id=#{issue_id} target_state=#{target_state} reason=#{inspect(reason)}")
-        end
-    end
-  end
-
-  defp revert_issue_state(_issue, _outcome), do: :ok
-
-  defp failed_step_count(%{steps: steps}) do
-    Enum.count(steps, fn step -> not step.passed end)
   end
 
   defp build_turn_prompt(issue, opts, 1, _max_turns), do: PromptBuilder.build_prompt(issue, opts)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -7,7 +7,7 @@ defmodule SymphonyElixir.Orchestrator do
   require Logger
   import Bitwise, only: [<<<: 2]
 
-  alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
+  alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Verification, Workspace}
   alias SymphonyElixir.Linear.Issue
 
   @continuation_retry_delay_ms 1_000
@@ -34,6 +34,7 @@ defmodule SymphonyElixir.Orchestrator do
       :tick_timer_ref,
       :tick_token,
       running: %{},
+      verifying: %{},
       completed: MapSet.new(),
       claimed: MapSet.new(),
       retry_attempts: %{},
@@ -116,47 +117,31 @@ defmodule SymphonyElixir.Orchestrator do
     {:noreply, state}
   end
 
-  def handle_info(
-        {:DOWN, ref, :process, _pid, reason},
-        %{running: running} = state
-      ) do
-    case find_issue_id_for_ref(running, ref) do
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case find_verifying_id_for_ref(state.verifying, ref) do
       nil ->
-        {:noreply, state}
+        handle_running_task_down(ref, reason, state)
 
       issue_id ->
-        {running_entry, state} = pop_running_entry(state, issue_id)
-        state = record_session_completion_totals(state, running_entry)
-        session_id = running_entry_session_id(running_entry)
+        handle_verifying_task_down(issue_id, reason, state)
+    end
+  end
 
-        state =
-          case reason do
-            :normal ->
-              Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
+  def handle_info({:verification_done, issue_id, outcome}, state) do
+    case Map.pop(state.verifying, issue_id) do
+      {nil, _} ->
+        Logger.warning("Verification result for unknown issue_id=#{issue_id}; ignoring")
+        {:noreply, state}
 
-              state
-              |> complete_issue(issue_id)
-              |> schedule_issue_retry(issue_id, 1, %{
-                identifier: running_entry.identifier,
-                delay_type: :continuation,
-                worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
-              })
+      {entry, new_verifying} ->
+        if is_reference(Map.get(entry, :ref)), do: Process.demonitor(entry.ref, [:flush])
 
-            _ ->
-              Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
+        steps = Map.get(outcome, :steps, [])
 
-              next_attempt = next_retry_attempt_from_running(running_entry)
+        Logger.info("Verification #{outcome.status} for issue_id=#{issue_id} issue_identifier=#{Map.get(entry, :identifier)} steps=#{length(steps)}")
 
-              schedule_issue_retry(state, issue_id, next_attempt, %{
-                identifier: running_entry.identifier,
-                error: "agent exited: #{inspect(reason)}",
-                worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
-              })
-          end
-
-        Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
+        state = %{state | verifying: new_verifying}
+        state = apply_verification_outcome(state, issue_id, entry, outcome.status)
 
         notify_dashboard()
         {:noreply, state}
@@ -218,6 +203,62 @@ defmodule SymphonyElixir.Orchestrator do
 
   def handle_info(msg, state) do
     Logger.debug("Orchestrator ignored message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  defp handle_running_task_down(ref, reason, %{running: running} = state) do
+    case find_issue_id_for_ref(running, ref) do
+      nil ->
+        {:noreply, state}
+
+      issue_id ->
+        {running_entry, state} = pop_running_entry(state, issue_id)
+        state = record_session_completion_totals(state, running_entry)
+        session_id = running_entry_session_id(running_entry)
+
+        state =
+          case reason do
+            :normal ->
+              Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling continuation check")
+
+              state
+              |> complete_issue(issue_id)
+              |> schedule_issue_retry(issue_id, 1, %{
+                identifier: running_entry.identifier,
+                delay_type: :continuation,
+                worker_host: Map.get(running_entry, :worker_host),
+                workspace_path: Map.get(running_entry, :workspace_path)
+              })
+
+            _ ->
+              Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
+
+              next_attempt = next_retry_attempt_from_running(running_entry)
+
+              schedule_issue_retry(state, issue_id, next_attempt, %{
+                identifier: running_entry.identifier,
+                error: "agent exited: #{inspect(reason)}",
+                worker_host: Map.get(running_entry, :worker_host),
+                workspace_path: Map.get(running_entry, :workspace_path)
+              })
+          end
+
+        Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
+
+        notify_dashboard()
+        {:noreply, state}
+    end
+  end
+
+  defp handle_verifying_task_down(issue_id, reason, state) do
+    {entry, new_verifying} = Map.pop(state.verifying, issue_id)
+
+    Logger.warning("Verification task exited without result for issue_id=#{issue_id} reason=#{inspect(reason)}; treating as skipped")
+
+    state = %{state | verifying: new_verifying}
+    state = apply_verification_outcome(state, issue_id, entry, :skipped)
+
+    notify_dashboard()
     {:noreply, state}
   end
 
@@ -355,9 +396,9 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
+        Logger.info("Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; gating on verification before cleanup")
 
-        terminate_running_issue(state, issue.id, true)
+        route_running_to_verification(state, issue.id)
 
       !issue_routable_to_worker?(issue) ->
         Logger.info("Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent")
@@ -859,10 +900,15 @@ defmodule SymphonyElixir.Orchestrator do
 
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace")
+        Logger.info("Issue state is terminal on continuation check: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; gating on verification before cleanup")
 
-        cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
-        {:noreply, release_issue_claim(state, issue_id)}
+        verify_metadata = %{
+          identifier: issue.identifier || Map.get(metadata, :identifier),
+          worker_host: Map.get(metadata, :worker_host),
+          workspace_path: Map.get(metadata, :workspace_path)
+        }
+
+        {:noreply, start_verification(state, issue_id, verify_metadata)}
 
       retry_candidate_issue?(issue, terminal_states) ->
         handle_active_retry(state, issue, attempt, metadata)
@@ -931,6 +977,124 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp release_issue_claim(%State{} = state, issue_id) do
     %{state | claimed: MapSet.delete(state.claimed, issue_id)}
+  end
+
+  defp start_verification(%State{} = state, issue_id, metadata) when is_binary(issue_id) and is_map(metadata) do
+    settings = Config.settings!().verification
+    workspace_path = Map.get(metadata, :workspace_path)
+
+    cond do
+      not settings.enabled ->
+        apply_verification_outcome(state, issue_id, metadata, :skipped)
+
+      not is_binary(workspace_path) ->
+        Logger.info("Cannot verify issue_id=#{issue_id} issue_identifier=#{Map.get(metadata, :identifier)}: workspace_path unavailable; treating as skipped")
+
+        apply_verification_outcome(state, issue_id, metadata, :skipped)
+
+      true ->
+        spawn_verification_task(state, issue_id, metadata, workspace_path, settings)
+    end
+  end
+
+  defp spawn_verification_task(%State{} = state, issue_id, metadata, workspace_path, settings) do
+    parent = self()
+
+    task_fun = fn ->
+      outcome = Verification.verify(workspace_path, settings)
+      send(parent, {:verification_done, issue_id, outcome})
+    end
+
+    case Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, task_fun) do
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+
+        Logger.info("Verification started for issue_id=#{issue_id} issue_identifier=#{Map.get(metadata, :identifier)} workspace=#{workspace_path}")
+
+        verifying_entry = Map.merge(metadata, %{pid: pid, ref: ref})
+        %{state | verifying: Map.put(state.verifying, issue_id, verifying_entry)}
+
+      {:error, reason} ->
+        Logger.warning("Verification task spawn failed for issue_id=#{issue_id} reason=#{inspect(reason)}; treating as skipped")
+
+        apply_verification_outcome(state, issue_id, metadata, :skipped)
+    end
+  end
+
+  defp apply_verification_outcome(%State{} = state, issue_id, entry, :fail) do
+    revert_issue_state(issue_id)
+
+    state
+    |> complete_issue(issue_id)
+    |> schedule_issue_retry(issue_id, 1, %{
+      identifier: Map.get(entry, :identifier),
+      delay_type: :continuation,
+      worker_host: Map.get(entry, :worker_host),
+      workspace_path: Map.get(entry, :workspace_path)
+    })
+  end
+
+  defp apply_verification_outcome(%State{} = state, issue_id, entry, _status) do
+    identifier = Map.get(entry, :identifier)
+    worker_host = Map.get(entry, :worker_host)
+
+    cleanup_issue_workspace(identifier, worker_host)
+
+    %{
+      state
+      | claimed: MapSet.delete(state.claimed, issue_id),
+        retry_attempts: Map.delete(state.retry_attempts, issue_id),
+        completed: MapSet.put(state.completed, issue_id)
+    }
+  end
+
+  defp revert_issue_state(issue_id) when is_binary(issue_id) do
+    active_states = Config.settings!().tracker.active_states
+
+    case List.last(active_states) do
+      nil ->
+        Logger.warning("Verification failed for issue_id=#{issue_id} but no active_states configured; cannot revert")
+
+      target_state ->
+        case Tracker.update_issue_state(issue_id, target_state) do
+          :ok ->
+            Logger.info("Verification reverted issue_id=#{issue_id} to state=#{target_state}")
+
+          {:error, reason} ->
+            Logger.warning("Verification revert failed issue_id=#{issue_id} target_state=#{target_state} reason=#{inspect(reason)}")
+        end
+    end
+  end
+
+  defp find_verifying_id_for_ref(verifying, ref) when is_map(verifying) and is_reference(ref) do
+    Enum.find_value(verifying, fn {issue_id, entry} ->
+      if Map.get(entry, :ref) == ref, do: issue_id
+    end)
+  end
+
+  defp find_verifying_id_for_ref(_verifying, _ref), do: nil
+
+  defp route_running_to_verification(%State{} = state, issue_id) when is_binary(issue_id) do
+    case Map.get(state.running, issue_id) do
+      nil ->
+        release_issue_claim(state, issue_id)
+
+      %{} = running_entry ->
+        pid = Map.get(running_entry, :pid)
+        ref = Map.get(running_entry, :ref)
+
+        if is_reference(ref), do: Process.demonitor(ref, [:flush])
+        if is_pid(pid), do: terminate_task(pid)
+
+        {_, state} = pop_running_entry(state, issue_id)
+        state = record_session_completion_totals(state, running_entry)
+
+        start_verification(state, issue_id, %{
+          identifier: running_entry.identifier,
+          worker_host: Map.get(running_entry, :worker_host),
+          workspace_path: Map.get(running_entry, :workspace_path)
+        })
+    end
   end
 
   defp retry_delay(attempt, metadata) when is_integer(attempt) and attempt > 0 and is_map(metadata) do

--- a/elixir/test/symphony_elixir/verify_before_advance_test.exs
+++ b/elixir/test/symphony_elixir/verify_before_advance_test.exs
@@ -1,0 +1,332 @@
+defmodule SymphonyElixir.VerifyBeforeAdvanceTest do
+  use SymphonyElixir.TestSupport
+
+  @moduledoc """
+  Exercises the verify-before-advance flow: when a running issue's tracker state
+  moves to terminal, the workspace must be preserved and verification must run
+  before claim release / workspace cleanup. On verify fail, the tracker must be
+  reverted so the run can redispatch against the same workspace.
+
+  Covers the root cause of the 2026-04-20 adversarial dogfood F2 finding.
+  """
+
+  setup do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_memory_recipient = Application.get_env(:symphony_elixir, :memory_tracker_recipient)
+    previous_executor = Application.get_env(:symphony_elixir, :verification_executor_module)
+
+    on_exit(fn ->
+      restore(previous_memory_issues, :memory_tracker_issues)
+      restore(previous_memory_recipient, :memory_tracker_recipient)
+      restore(previous_executor, :verification_executor_module)
+    end)
+
+    :ok
+  end
+
+  defp restore(nil, key), do: Application.delete_env(:symphony_elixir, key)
+  defp restore(value, key), do: Application.put_env(:symphony_elixir, key, value)
+
+  defp fresh_workspace_root(tag) do
+    Path.join(
+      System.tmp_dir!(),
+      "opal-verify-before-advance-#{tag}-#{System.unique_integer([:positive])}"
+    )
+  end
+
+  defp workspace_for(root, identifier) do
+    path = Path.join(root, identifier)
+    File.mkdir_p!(path)
+    path
+  end
+
+  defp write_recipe!(workspace, steps) do
+    File.mkdir_p!(Path.join(workspace, ".opal"))
+    File.write!(Path.join(workspace, ".opal/verify.json"), Jason.encode!(%{"steps" => steps}))
+  end
+
+  defp running_entry(workspace, issue_id, identifier, agent_pid, ref \\ nil) do
+    %{
+      pid: agent_pid,
+      ref: ref,
+      identifier: identifier,
+      issue: %Issue{id: issue_id, identifier: identifier, state: "In Progress"},
+      workspace_path: workspace,
+      worker_host: nil,
+      started_at: DateTime.utc_now()
+    }
+  end
+
+  defp terminal_issue(issue_id, identifier) do
+    %Issue{
+      id: issue_id,
+      identifier: identifier,
+      state: "Closed",
+      title: "Done",
+      description: "Closed by agent",
+      labels: []
+    }
+  end
+
+  defp spawn_agent do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      after
+        60_000 -> :ok
+      end
+    end)
+  end
+
+  defp wait_until(fun, attempts \\ 80, delay_ms \\ 25)
+  defp wait_until(_fun, 0, _delay_ms), do: :timeout
+
+  defp wait_until(fun, attempts, delay_ms) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(delay_ms)
+      wait_until(fun, attempts - 1, delay_ms)
+    end
+  end
+
+  test "reconcile-terminal with verification disabled cleans up workspace" do
+    # Regression guard: the pre-F2 behaviour (straight cleanup) must still apply
+    # when verification.enabled is false (the schema default).
+    root = fresh_workspace_root("disabled")
+    identifier = "OPAL-1001"
+    workspace = workspace_for(root, identifier)
+    issue_id = "issue-disabled"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      workspace_root: root
+    )
+
+    state = %Orchestrator.State{
+      running: %{issue_id => running_entry(workspace, issue_id, identifier, spawn_agent())},
+      claimed: MapSet.new([issue_id]),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{},
+      verifying: %{}
+    }
+
+    updated = Orchestrator.reconcile_issue_states_for_test([terminal_issue(issue_id, identifier)], state)
+
+    refute Map.has_key?(updated.running, issue_id)
+    refute Map.has_key?(updated.verifying, issue_id)
+    refute MapSet.member?(updated.claimed, issue_id)
+    refute File.exists?(workspace)
+
+    File.rm_rf(root)
+  end
+
+  test "reconcile-terminal with verification enabled preserves workspace while verifying, then cleans up on pass" do
+    root = fresh_workspace_root("pass")
+    identifier = "OPAL-1002"
+    workspace = workspace_for(root, identifier)
+    write_recipe!(workspace, [%{"name" => "ok", "shell" => "true"}])
+
+    issue_id = "issue-pass"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      workspace_root: root,
+      verification_enabled: true
+    )
+
+    orchestrator_name = Module.concat(__MODULE__, :PassOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :normal)
+      File.rm_rf(root)
+    end)
+
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [terminal_issue(issue_id, identifier)])
+
+    :sys.replace_state(pid, fn state ->
+      state
+      |> Map.put(:running, %{issue_id => running_entry(workspace, issue_id, identifier, spawn_agent())})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+    end)
+
+    # Trigger reconcile via the poll cycle. reconcile_running_issues fetches
+    # memory-tracker state, sees terminal, and routes through verify.
+    send(pid, :run_poll_cycle)
+
+    :ok =
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        not Map.has_key?(state.verifying, issue_id) and not File.exists?(workspace)
+      end)
+
+    state = :sys.get_state(pid)
+    refute Map.has_key?(state.running, issue_id)
+    refute MapSet.member?(state.claimed, issue_id)
+    refute File.exists?(workspace)
+  end
+
+  test "reconcile-terminal with failing recipe reverts tracker and preserves workspace" do
+    root = fresh_workspace_root("fail")
+    identifier = "OPAL-1003"
+    workspace = workspace_for(root, identifier)
+    write_recipe!(workspace, [%{"name" => "boom", "shell" => "false"}])
+
+    issue_id = "issue-fail"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      workspace_root: root,
+      verification_enabled: true,
+      tracker_active_states: ["Todo", "In Progress"],
+      tracker_terminal_states: ["Closed"]
+    )
+
+    orchestrator_name = Module.concat(__MODULE__, :FailOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :normal)
+      File.rm_rf(root)
+    end)
+
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [terminal_issue(issue_id, identifier)])
+    Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+    :sys.replace_state(pid, fn state ->
+      state
+      |> Map.put(:running, %{issue_id => running_entry(workspace, issue_id, identifier, spawn_agent())})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+    end)
+
+    send(pid, :run_poll_cycle)
+
+    # Verify fail reverts tracker to the last configured active state.
+    assert_receive {:memory_tracker_state_update, ^issue_id, "In Progress"}, 2_000
+
+    :ok =
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        not Map.has_key?(state.verifying, issue_id)
+      end)
+
+    state = :sys.get_state(pid)
+    refute Map.has_key?(state.running, issue_id)
+    refute Map.has_key?(state.verifying, issue_id)
+    assert File.exists?(workspace), "workspace must survive verify fail so agent can retry"
+    # Retry is scheduled so the reverted issue will be picked up again.
+    assert Map.has_key?(state.retry_attempts, issue_id)
+  end
+
+  test "continuation-retry terminal check routes through verify" do
+    root = fresh_workspace_root("cont")
+    identifier = "OPAL-1004"
+    workspace = workspace_for(root, identifier)
+    write_recipe!(workspace, [%{"name" => "ok", "shell" => "true"}])
+
+    issue_id = "issue-cont"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      workspace_root: root,
+      verification_enabled: true
+    )
+
+    orchestrator_name = Module.concat(__MODULE__, :ContinuationOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :normal)
+      File.rm_rf(root)
+    end)
+
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [terminal_issue(issue_id, identifier)])
+
+    ref = make_ref()
+    running = running_entry(workspace, issue_id, identifier, spawn_agent(), ref)
+
+    :sys.replace_state(pid, fn state ->
+      state
+      |> Map.put(:running, %{issue_id => running})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+    end)
+
+    # :DOWN :normal triggers the continuation-retry path. The scheduled retry
+    # fires after 1s, refetches tracker state, sees terminal, and must route
+    # through verify (rather than cleaning the workspace directly).
+    send(pid, {:DOWN, ref, :process, running.pid, :normal})
+
+    :ok =
+      wait_until(
+        fn ->
+          state = :sys.get_state(pid)
+
+          not Map.has_key?(state.running, issue_id) and
+            not Map.has_key?(state.verifying, issue_id) and
+            not File.exists?(workspace)
+        end,
+        200,
+        25
+      )
+
+    state = :sys.get_state(pid)
+    refute File.exists?(workspace)
+    refute MapSet.member?(state.claimed, issue_id)
+  end
+
+  defmodule CrashingExecutor do
+    @behaviour SymphonyElixir.Verification.Executor
+
+    @impl true
+    def run_step(_step, _workspace, _opts), do: raise("executor boom")
+  end
+
+  test "verification task crash is treated as skipped and releases the claim" do
+    # If the verify task itself dies before sending :verification_done, the
+    # orchestrator's :DOWN handler must still move the issue out of :verifying
+    # rather than wedging the claim forever.
+    root = fresh_workspace_root("crash")
+    identifier = "OPAL-1005"
+    workspace = workspace_for(root, identifier)
+    write_recipe!(workspace, [%{"name" => "will-crash", "shell" => "true"}])
+
+    issue_id = "issue-crash"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      workspace_root: root,
+      verification_enabled: true
+    )
+
+    orchestrator_name = Module.concat(__MODULE__, :CrashOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :normal)
+      File.rm_rf(root)
+    end)
+
+    Application.put_env(:symphony_elixir, :verification_executor_module, CrashingExecutor)
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [terminal_issue(issue_id, identifier)])
+
+    :sys.replace_state(pid, fn state ->
+      state
+      |> Map.put(:running, %{issue_id => running_entry(workspace, issue_id, identifier, spawn_agent())})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+    end)
+
+    send(pid, :run_poll_cycle)
+
+    :ok =
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        not Map.has_key?(state.verifying, issue_id)
+      end)
+
+    state = :sys.get_state(pid)
+    refute Map.has_key?(state.running, issue_id)
+    refute Map.has_key?(state.verifying, issue_id)
+    refute MapSet.member?(state.claimed, issue_id)
+  end
+end


### PR DESCRIPTION
#### Context

Adversarial dogfood #27 found verification never fired: terminal tracker state triggered `terminate_running_issue(cleanup_workspace: true)`, deleting `.opal/verify.json` before the verify hook could read it. Closes #30.

#### TL;DR

Funnel terminal-state entry points through a `:verifying` bucket so verify runs against an intact workspace before tracker advance.

#### Summary

- Both `reconcile_issue_state` and `handle_retry_issue_lookup` now route through `start_verification`, which terminates the runner without cleaning the workspace.
- `apply_verification_outcome` cleans up on pass/skipped or reverts the tracker + schedules continuation-retry on fail.
- `:DOWN :normal` keeps continuation-retry semantics so max-turns exits don't spuriously verify.
- New `verify_before_advance_test.exs` covers 5 scenarios: disabled-cleanup-preserved, pass-cleans-after-verify, fail-reverts-tracker-preserves-workspace, continuation-route, task-crash-treated-as-skipped.

#### Alternatives

- Option A from #30 (agent writes `.opal/done`, Opal runs verify before transitioning tracker): rejected — requires changes to every runtime + prompt; less robust to legacy/unmodified agents.
- Add a no-cleanup flag to `terminate_running_issue`: rejected — leaks state-machine concerns into the cleanup helper.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix test test/symphony_elixir/verify_before_advance_test.exs` — 5/5 pass
- [x] Full suite — 346/348 (2 pre-existing timing flakes in `core_test.exs:544/584`)
- [ ] Re-run adversarial dogfood (#27 scenario) on this branch to confirm verify fires before workspace cleanup