### PR TITLE
[codex] Define Opal golden path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # Opal — Orchestrated Project Agent Layer
 
-Opal is a containerized agent orchestrator that can work on any project. Mount a project volume,
-point Opal at it, and autonomous coding agents pick up issues from GitHub and deliver PRs — guided
-by the project's own documentation.
+Opal is a containerized agent orchestrator for one developer and many projects. Mount a project
+volume, point Opal at GitHub Issues, and Claude Code agents pick up issues, work in isolated
+workspaces, and hand you pull requests — guided by the project's own documentation. The product
+direction is to make every handoff pass through self-verification first.
 
-Built on [OpenAI's Symphony](https://github.com/openai/symphony) orchestration framework (Elixir/OTP),
-extended with:
+Built on [OpenAI's Symphony](https://github.com/openai/symphony) orchestration framework
+(Elixir/OTP), narrowed around Opal's golden path:
 
-- **GitHub Issues** as the task source (replacing Linear)
-- **Claude Code** (`claude -p`) as the agent runtime (replacing Codex)
+- **GitHub Issues** as the default task source
+- **Claude Code** (`claude -p`) as the default agent runtime
+- **Self-verification** through `.opal/verify.json` recipes before handoff
 - **Project-adaptive prompts** that read your project's own CLAUDE.md / README and follow them
 - **Per-project knowledge** — Opal accumulates experience knowledge per target project and injects
   it into each agent run, without polluting the target repo
 - **Docker packaging** for drop-in use with any codebase
 
 > [!WARNING]
-> Opal is under active development. The three adapter issues are tracked in GitHub Issues.
+> Opal is under active development. The supported happy path is Docker + GitHub Issues +
+> Claude Code. Linear and Codex remain compatibility paths inherited from Symphony.
 
 ## Vision
 
@@ -24,24 +27,63 @@ See [VISION.md](VISION.md) — what Opal is, who it's for, and the three pillars
 
 ## Quickstart
 
+Build the image:
+
 ```bash
-docker run -v /path/to/your-project:/project \
-           -v /tmp/workspaces:/workspace \
-           -e GITHUB_TOKEN=ghp_... \
-           opal:latest
+docker build -t opal .
+```
+
+Prepare the target GitHub repo with issue labels matching Opal's default states:
+
+- `todo`
+- `in-progress`
+- `human-review`
+
+Then run Opal from the project checkout you want it to operate on:
+
+```bash
+docker run --rm -it \
+  -p 4000:4000 \
+  -v "$PWD":/project \
+  -v /tmp/opal-workspaces:/workspace \
+  -e GITHUB_TOKEN=ghp_... \
+  -e GITHUB_REPO=owner/repo \
+  opal
 ```
 
 Opal reads the project's documentation, polls GitHub Issues for work, creates isolated workspaces,
 and runs Claude Code agents to implement, test, and open PRs — all without project-specific
 configuration.
 
+Open <http://localhost:4000> to watch the live dashboard.
+
+## Golden Path
+
+The first path Opal is optimizing for is intentionally narrow:
+
+1. Poll GitHub Issues with state labels.
+2. Create one workspace per issue under `/workspace`.
+3. Clone `/project` into the issue workspace.
+4. Create a branch using the issue number.
+5. Run Claude Code via `claude -p`.
+6. Require the agent to emit `.opal/verify.json`.
+7. Execute the verification recipe from the workspace.
+8. Feed failures back into a follow-up turn, or hand off a PR when verification passes.
+9. Distill useful run evidence into the per-project knowledge layer.
+
+Other tracker/runtime adapters should preserve this flow rather than redefine it.
+
 ## Roadmap
+
+Current focus:
 
 | # | Feature | Status |
 |---|---------|--------|
-| [#1](https://github.com/apexphere/opal/issues/1) | GitHub Issues tracker adapter | Planned |
-| [#2](https://github.com/apexphere/opal/issues/2) | Claude Code agent adapter (`claude -p`) | Planned |
-| [#3](https://github.com/apexphere/opal/issues/3) | Generic prompt + Docker packaging | Planned |
+| [#46](https://github.com/apexphere/opal/issues/46) | Make Docker + GitHub + Claude Code the canonical golden path | Active |
+| [#47](https://github.com/apexphere/opal/issues/47) | Add deterministic golden-path fake run test | Planned |
+| [#48](https://github.com/apexphere/opal/issues/48) | Make self-verification a required gate in the default Opal flow | Planned |
+| [#49](https://github.com/apexphere/opal/issues/49) | Capture useful wiki learning from completed or failed verification runs | Planned |
+| [#50](https://github.com/apexphere/opal/issues/50) | Expose a concise operator narrative for where Opal is and what happens next | Planned |
 
 ## Current state
 
@@ -49,13 +91,17 @@ The codebase is forked from [openai/symphony](https://github.com/openai/symphony
 
 - **Orchestrator** — GenServer polling loop with concurrency, retries, and reconciliation
 - **Workspace manager** — per-issue isolation with lifecycle hooks
+- **Tracker adapters** — GitHub by default, plus Linear and memory adapters
+- **Agent runtimes** — Claude Code by default, plus Codex app-server compatibility
+- **Self-verification** — workspace-local recipes and verification logs
 - **Knowledge subsystem** — per-project experience knowledge, filesystem-backed by default,
   dynamically injected into each agent run (see SPEC §9.6)
 - **Prompt builder** — Liquid template rendering with task context
 - **Observability** — terminal dashboard + Phoenix LiveView UI
 - **SPEC.md** — language-agnostic specification for building your own
 
-See [elixir/README.md](elixir/README.md) for the Elixir reference implementation setup.
+See [docker/README.md](docker/README.md) for the default runtime path and
+[elixir/README.md](elixir/README.md) for implementation details.
 
 ## License
 

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -1,18 +1,18 @@
 ---
-# Sample WORKFLOW.md for projects that want Opal to work on their issues.
+# Sample WORKFLOW.md for projects that want to customize Opal's default flow.
 # Drop this at your project root as `WORKFLOW.md`, fill in `repo`, and
 # run Opal via Docker (see docker/README.md).
 
 tracker:
-  kind: github                  # or "linear" / "memory"
+  kind: github                  # default; "linear" and "memory" are compatibility/test adapters
   repo: $GITHUB_REPO            # owner/repo — env var or hardcoded
   api_key: $GITHUB_TOKEN        # GitHub PAT or App token
   active_states: ["Todo", "In Progress"]
   terminal_states: ["Done", "Closed"]
-  # labels_prefix: "opal:"      # optional — namespace state labels
+  # labels_prefix: "opal:"      # optional — namespaces labels like opal:todo
 
 agent:
-  runtime: claude-code          # or "codex"
+  runtime: claude-code          # default; "codex" is a compatibility runtime
   max_concurrent_agents: 1      # how many issues to work in parallel
   max_turns: 20                 # max agent turns per issue
 
@@ -32,13 +32,15 @@ claude_code:
 #   after_create: "git clone $REPO_URL ."
 #   before_run: "make setup"
 #   after_run: "make test"
----
 
-# Optional: project-specific prompt body (Liquid template).
+# Optional self-verification gate. This is the product direction, but projects
+# can opt in before it becomes mandatory in the Docker default.
+# verification:
+#   enabled: true
+#   required: true
 #
-# Leave this section empty to use Opal's built-in generic project-adaptive
-# prompt (which tells the agent to read your CLAUDE.md / AGENTS.md /
-# README.md / CONTRIBUTING.md and follow them as authoritative).
+# Optional: add a project-specific prompt body after the second `---`.
+# Leave the body empty to use Opal's built-in generic project-adaptive prompt.
 #
 # Available template variables:
 #   {{ task.number }}       — issue identifier (e.g. "#42" or "MT-123")
@@ -50,3 +52,4 @@ claude_code:
 #   {{ attempt }}            — retry attempt number (only on retries)
 #
 # (Legacy `{{ issue.X }}` aliases also work.)
+---

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,10 +15,19 @@ The image expects two volumes and two environment variables:
 
 | Path / var      | Purpose                                        |
 | --------------- | ---------------------------------------------- |
-| `/project`      | Bind-mount of the project Opal is working on   |
+| `/project`      | Bind-mount of the project Opal clones per issue |
 | `/workspace`    | Bind-mount where per-issue workspaces are kept |
 | `GITHUB_TOKEN`  | GitHub PAT or GitHub App token                 |
 | `GITHUB_REPO`   | `owner/repo` (only used by the default config) |
+
+Before starting, make sure the target repo has labels for Opal's default issue states:
+
+- `todo`
+- `in-progress`
+- `human-review`
+
+Open issues with the `todo` label are eligible for pickup. Opal swaps the state label as work
+progresses; closing the issue represents `Done` / `Closed`.
 
 Minimal invocation:
 
@@ -53,14 +62,19 @@ The entrypoint picks the first match it finds:
 2. `/etc/opal/default-WORKFLOW.md` — the image's built-in default
 
 The default WORKFLOW.md ships with `tracker.kind: github`, `agent.runtime:
-claude-code`, and an empty prompt body — which causes Opal to use its built-in
-generic project-adaptive prompt. That prompt tells the agent to read your
-project's `CLAUDE.md` / `AGENTS.md` / `README.md` / `CONTRIBUTING.md` and
-follow them as authoritative.
+claude-code`, an `after_create` hook that runs `git clone /project .` inside
+each new issue workspace, and an empty prompt body — which causes Opal to use
+its built-in generic project-adaptive prompt. That prompt tells the agent to
+read your project's `CLAUDE.md` / `AGENTS.md` / `README.md` /
+`CONTRIBUTING.md` and follow them as authoritative.
 
 In other words: a project with no Opal-specific config gets sensible defaults.
 A project that wants to customize anything just drops a `WORKFLOW.md` at its
 root.
+
+The default config is intentionally narrow: GitHub Issues + Claude Code +
+Docker workspaces. Linear and Codex are still available in the Elixir
+implementation for compatibility, but they are not the default Docker path.
 
 ## Project agent docs
 
@@ -78,6 +92,15 @@ You don't need to do anything special — just have those files in your repo.
 Drop a `WORKFLOW.md` at your project root with YAML front matter and an
 optional Liquid template body. See the repo-root `WORKFLOW.example.md` for a
 ready-to-copy starting point.
+
+Common overrides:
+
+- `tracker.labels_prefix` namespaces state labels, for example `opal:todo`.
+- `agent.max_concurrent_agents` raises or lowers the number of issues Opal may work at once.
+- `hooks.after_create` can replace the default `git clone /project .` bootstrap if a project needs
+  a different checkout or setup flow.
+- `verification.enabled` and `verification.required` turn the self-verification gate on for a
+  project before it becomes the Docker default.
 
 ## Image contents
 

--- a/docker/default-WORKFLOW.md
+++ b/docker/default-WORKFLOW.md
@@ -3,6 +3,11 @@ tracker:
   kind: github
   repo: $GITHUB_REPO
   api_key: $GITHUB_TOKEN
+  # GitHub labels backing the default state machine:
+  #   Todo -> `todo`
+  #   In Progress -> `in-progress`
+  #   Human Review -> `human-review`
+  # Closed issues are treated as Done / Closed.
   active_states: ["Todo", "In Progress"]
   terminal_states: ["Done", "Closed"]
 agent:
@@ -11,6 +16,9 @@ agent:
   max_turns: 20
 workspace:
   root: /workspace
+hooks:
+  after_create: |
+    git clone /project .
 polling:
   interval_ms: 30000
 claude_code:
@@ -23,5 +31,3 @@ server:
   host: "0.0.0.0"
   port: 4000
 ---
-
-(Empty body — Opal will use its built-in generic project-adaptive prompt.)

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -1,6 +1,8 @@
-# Symphony Elixir
+# Opal Elixir
 
-This directory contains the Elixir agent orchestration service that polls Linear, creates per-issue workspaces, and runs Codex in app-server mode.
+This directory contains the Elixir agent orchestration service. Opal's golden path is GitHub
+Issues + Claude Code + Docker workspaces; Linear and Codex remain compatibility paths inherited
+from Symphony.
 
 ## Environment
 
@@ -19,7 +21,7 @@ This directory contains the Elixir agent orchestration service that polls Linear
     change where practical so the spec stays current.
 - Prefer adding config access through `SymphonyElixir.Config` instead of ad-hoc env reads.
 - Workspace safety is critical:
-  - Never run Codex turn cwd in source repo.
+  - Never run an agent turn cwd in the source repo.
   - Workspaces must stay under configured workspace root.
 - Orchestrator behavior is stateful and concurrency-sensitive; preserve retry, reconciliation, and cleanup semantics.
 - Follow `docs/logging.md` for logging conventions and required issue/session context fields.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,24 +1,35 @@
-# Symphony Elixir
+# Opal Elixir
 
-This directory contains the current Elixir/OTP implementation of Symphony, based on
-[`SPEC.md`](../SPEC.md) at the repository root.
+This directory contains Opal's Elixir/OTP implementation. It began as the Symphony reference
+implementation described by [`SPEC.md`](../SPEC.md), and now carries Opal's default path:
+GitHub Issues as the tracker, Claude Code (`claude -p`) as the runtime, Docker workspaces, and
+project-scoped knowledge.
 
 > [!WARNING]
-> Symphony Elixir is prototype software intended for evaluation only and is presented as-is.
-> We recommend implementing your own hardened version based on `SPEC.md`.
+> Opal is prototype software intended for evaluation only and is presented as-is. The supported
+> first-run path is the Docker image documented in [`../docker/README.md`](../docker/README.md).
 
 ## Screenshot
 
-![Symphony Elixir screenshot](../.github/media/elixir-screenshot.png)
+![Opal Elixir screenshot](../.github/media/elixir-screenshot.png)
 
 ## How it works
 
-1. Polls Linear for candidate work
+Default Opal flow:
+
+1. Polls GitHub Issues for candidate work
 2. Creates a workspace per issue
-3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
-   workspace
-4. Sends a workflow prompt to Codex
-5. Keeps Codex working on the issue until the work is done
+3. Creates or checks out an issue branch
+4. Launches Claude Code (`claude -p`) inside the workspace
+5. Sends a project-adaptive workflow prompt
+6. Runs self-verification when enabled
+7. Keeps working or hands off a PR according to the issue state
+
+Compatibility paths still exist:
+
+- Linear can be used as a tracker via `tracker.kind: linear`.
+- Codex can be used as a runtime via `agent.runtime: codex` and
+  [App Server mode](https://developers.openai.com/codex/app-server/).
 
 During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that repo
 skills can make raw Linear GraphQL calls.
@@ -26,7 +37,24 @@ skills can make raw Linear GraphQL calls.
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
 
-## How to use it
+## How to use the default Opal path
+
+Use Docker unless you are developing the Elixir implementation itself:
+
+```bash
+docker build -t opal ..
+docker run --rm -it \
+  -p 4000:4000 \
+  -v "$PWD/..":/project \
+  -v /tmp/opal-workspaces:/workspace \
+  -e GITHUB_TOKEN=ghp_... \
+  -e GITHUB_REPO=owner/repo \
+  opal
+```
+
+See [`../docker/README.md`](../docker/README.md) for the full Docker setup.
+
+## How to use the legacy Linear/Codex workflow
 
 1. Make sure your codebase is set up to work well with agents: see
    [Harness engineering](https://openai.com/index/harness-engineering/).


### PR DESCRIPTION
#### Context

Closes #46. The docs still made inherited Symphony paths feel like the default.

#### TL;DR

*Make Docker + GitHub + Claude Code the documented Opal happy path.*

#### Summary

- Refresh the root README around the golden path and active roadmap.
- Document GitHub labels and Docker defaults for first-run setup.
- Make the Docker workflow clone `/project` into each issue workspace.
- Keep Linear and Codex documented as compatibility paths.
- Ensure default/example workflows have empty prompt bodies.

#### Alternatives

- Leave legacy Linear/Codex docs prominent, but that keeps the product path split.
- Enable required verification now, but #48 tracks that after stronger test coverage.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `git diff --check`
- [x] YAML front matter parse for `docker/default-WORKFLOW.md` and `WORKFLOW.example.md`
- [x] Confirm both default workflow bodies are empty so built-in prompt is used

Note: full Elixir validation was not run because this worktree's `elixir/mise.toml` is not trusted yet.