### PR TITLE
[codex] Require verification in the default flow

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -63,10 +63,10 @@ The entrypoint picks the first match it finds:
 
 The default WORKFLOW.md ships with `tracker.kind: github`, `agent.runtime:
 claude-code`, an `after_create` hook that runs `git clone /project .` inside
-each new issue workspace, and an empty prompt body — which causes Opal to use
-its built-in generic project-adaptive prompt. That prompt tells the agent to
-read your project's `CLAUDE.md` / `AGENTS.md` / `README.md` /
-`CONTRIBUTING.md` and follow them as authoritative.
+each new issue workspace, required self-verification, and an empty prompt body
+— which causes Opal to use its built-in generic project-adaptive prompt. That
+prompt tells the agent to read your project's `CLAUDE.md` / `AGENTS.md` /
+`README.md` / `CONTRIBUTING.md` and follow them as authoritative.
 
 In other words: a project with no Opal-specific config gets sensible defaults.
 A project that wants to customize anything just drops a `WORKFLOW.md` at its
@@ -99,8 +99,8 @@ Common overrides:
 - `agent.max_concurrent_agents` raises or lowers the number of issues Opal may work at once.
 - `hooks.after_create` can replace the default `git clone /project .` bootstrap if a project needs
   a different checkout or setup flow.
-- `verification.enabled` and `verification.required` turn the self-verification gate on for a
-  project before it becomes the Docker default.
+- `verification.enabled` and `verification.required` can be set to `false` for a project that needs
+  to temporarily opt out of the default self-verification gate.
 
 ## Image contents
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,6 +69,17 @@ project-adaptive prompt. That prompt tells the agent to read your project's
 `CLAUDE.md` / `AGENTS.md` / `README.md` / `CONTRIBUTING.md` and follow them as
 authoritative.
 
+Because the default recipe critic invokes `codex exec`, mount an authenticated
+Codex config into the container, for example `-v "$HOME/.codex":/root/.codex:ro`.
+If you do not want to provide Codex auth yet, set
+`verification.critic_enabled: false` in your project `WORKFLOW.md`; verification
+still runs, but recipe-quality criticism is skipped.
+
+Docker uses a 10-minute `verification.step_timeout_ms` so real project
+integration checks have room to boot services and exercise the delivered
+surface. Lower it in `WORKFLOW.md` if a broken verification step should fail
+faster for your project.
+
 In other words: a project with no Opal-specific config gets sensible defaults.
 A project that wants to customize anything just drops a `WORKFLOW.md` at its
 root.
@@ -103,6 +114,7 @@ Common overrides:
 - `verification.enabled`, `verification.required`, and `verification.critic_enabled` can be set to
   `false` for a project that needs to temporarily opt out of the default self-verification gate or
   recipe critic.
+- `verification.step_timeout_ms` controls the per-step timeout for verification commands.
 
 ## Image contents
 

--- a/docker/default-WORKFLOW.md
+++ b/docker/default-WORKFLOW.md
@@ -21,6 +21,10 @@ hooks:
     git clone /project .
 polling:
   interval_ms: 30000
+verification:
+  enabled: true
+  required: true
+  step_timeout_ms: 600000
 claude_code:
   command: claude
   permission_mode: acceptEdits

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -859,7 +859,7 @@ defmodule SymphonyElixir.Orchestrator do
 
     timer_ref = Process.send_after(self(), {:retry_issue, issue_id, retry_token}, delay_ms)
 
-    error_suffix = if is_binary(error), do: " error=#{error}", else: ""
+    error_suffix = retry_error_log_suffix(error)
 
     Logger.warning("Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}")
 
@@ -1108,34 +1108,55 @@ defmodule SymphonyElixir.Orchestrator do
     }
   end
 
-  defp verification_retry_error(%{status: :rejected, rejection: %{reason: reason}})
+  defp verification_retry_error(%{status: :rejected, rejection: %{reason: reason, missing_coverage: missing}})
        when is_binary(reason) and reason != "" do
-    "verification rejected: #{reason}"
+    %{
+      code: :verification_rejected,
+      message: "verification rejected: #{reason}",
+      detail: %{reason: reason, missing_coverage: missing}
+    }
   end
 
-  defp verification_retry_error(%{status: :rejected}), do: "verification rejected"
+  defp verification_retry_error(%{status: :rejected}) do
+    %{code: :verification_rejected, message: "verification rejected"}
+  end
 
   defp verification_retry_error(%{skipped_reason: reason}) when not is_nil(reason) do
-    "verification failed: #{format_verification_reason(reason)}"
+    message = "verification failed: #{format_verification_reason(reason)}"
+    code = if reason == :no_recipe, do: :no_recipe, else: :verification_failed
+
+    %{code: code, message: message, detail: %{reason: reason}}
   end
 
   defp verification_retry_error(%{steps: steps}) when is_list(steps) do
     case Enum.find(steps, &(Map.get(&1, :passed) == false)) do
       %{name: name, exit: exit, expect_exit: expect_exit} ->
-        "verification failed: #{name} exited #{format_verification_exit(exit)} (expected #{expect_exit})"
+        %{
+          code: :verification_failed,
+          message: "verification failed: #{name} exited #{format_verification_exit(exit)} (expected #{expect_exit})",
+          detail: %{step: name, exit: exit, expect_exit: expect_exit}
+        }
 
       _ ->
-        "verification failed"
+        %{code: :verification_failed, message: "verification failed"}
     end
   end
 
-  defp verification_retry_error(_outcome), do: "verification failed"
+  defp verification_retry_error(_outcome), do: %{code: :verification_failed, message: "verification failed"}
 
   defp format_verification_exit(:timeout), do: "timeout"
   defp format_verification_exit(exit), do: to_string(exit)
 
   defp format_verification_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
   defp format_verification_reason(reason), do: inspect(reason)
+
+  defp retry_error_log_suffix(nil), do: ""
+  defp retry_error_log_suffix(error), do: " error=#{retry_error_message(error)}"
+
+  defp retry_error_message(%{message: message}) when is_binary(message), do: message
+  defp retry_error_message(%{"message" => message}) when is_binary(message), do: message
+  defp retry_error_message(error) when is_binary(error), do: error
+  defp retry_error_message(error), do: inspect(error)
 
   defp bump_critic_rejection_attempts(%State{} = state, issue_id, count) do
     %{state | critic_rejection_attempts: Map.put(state.critic_rejection_attempts, issue_id, count)}

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1034,6 +1034,7 @@ defmodule SymphonyElixir.Orchestrator do
     |> schedule_issue_retry(issue_id, 1, %{
       identifier: Map.get(entry, :identifier),
       delay_type: :continuation,
+      error: verification_retry_error(outcome),
       worker_host: Map.get(entry, :worker_host),
       workspace_path: Map.get(entry, :workspace_path)
     })
@@ -1052,6 +1053,28 @@ defmodule SymphonyElixir.Orchestrator do
         completed: MapSet.put(state.completed, issue_id)
     }
   end
+
+  defp verification_retry_error(%{skipped_reason: reason}) when not is_nil(reason) do
+    "verification failed: #{format_verification_reason(reason)}"
+  end
+
+  defp verification_retry_error(%{steps: steps}) when is_list(steps) do
+    case Enum.find(steps, &(Map.get(&1, :passed) == false)) do
+      %{name: name, exit: exit, expect_exit: expect_exit} ->
+        "verification failed: #{name} exited #{format_verification_exit(exit)} (expected #{expect_exit})"
+
+      _ ->
+        "verification failed"
+    end
+  end
+
+  defp verification_retry_error(_outcome), do: "verification failed"
+
+  defp format_verification_exit(:timeout), do: "timeout"
+  defp format_verification_exit(exit), do: to_string(exit)
+
+  defp format_verification_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_verification_reason(reason), do: inspect(reason)
 
   defp maybe_cast_failure_to_curator(issue_id, entry, outcome) do
     cond do

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -681,6 +681,20 @@ defmodule SymphonyElixir.StatusDashboard do
   defp next_in_words(_), do: "n/a"
 
   defp format_retry_error(error) when is_binary(error) do
+    retry_error_suffix(error)
+  end
+
+  defp format_retry_error(%{message: message}) when is_binary(message) do
+    retry_error_suffix(message)
+  end
+
+  defp format_retry_error(%{"message" => message}) when is_binary(message) do
+    retry_error_suffix(message)
+  end
+
+  defp format_retry_error(_), do: ""
+
+  defp retry_error_suffix(error) do
     sanitized =
       error
       |> String.replace("\\r\\n", " ")
@@ -698,8 +712,6 @@ defmodule SymphonyElixir.StatusDashboard do
       " " <> colorize("error=#{truncate(sanitized, 96)}", @ansi_dim)
     end
   end
-
-  defp format_retry_error(_), do: ""
 
   defp format_runtime_seconds(seconds) when is_integer(seconds) do
     mins = div(seconds, 60)

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -237,7 +237,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
                     </td>
                     <td><%= entry.attempt %></td>
                     <td class="mono"><%= entry.due_at || "n/a" %></td>
-                    <td><%= entry.error || "n/a" %></td>
+                    <td><%= retry_error_text(entry.error) %></td>
                   </tr>
                 </tbody>
               </table>
@@ -308,6 +308,11 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp format_int(_value), do: "n/a"
+
+  defp retry_error_text(%{message: message}) when is_binary(message), do: message
+  defp retry_error_text(%{"message" => message}) when is_binary(message), do: message
+  defp retry_error_text(error) when is_binary(error) and error != "", do: error
+  defp retry_error_text(_error), do: "n/a"
 
   defp state_badge_class(state) do
     base = "state-badge"

--- a/elixir/test/symphony_elixir/golden_path_test.exs
+++ b/elixir/test/symphony_elixir/golden_path_test.exs
@@ -56,17 +56,20 @@ defmodule SymphonyElixir.GoldenPathTest do
     end
 
     defp write_verification_recipe!(workspace, identifier) do
-      File.mkdir_p!(Path.join(workspace, ".opal"))
       recipe_mode = Application.get_env(:symphony_elixir, :golden_path_test_recipe_mode, :pass)
 
-      File.write!(
-        Path.join(workspace, ".opal/verify.json"),
-        Jason.encode!(%{
-          "version" => "1",
-          "description" => "golden path workspace proof",
-          "steps" => recipe_steps(recipe_mode, identifier)
-        })
-      )
+      if recipe_mode != :missing do
+        File.mkdir_p!(Path.join(workspace, ".opal"))
+
+        File.write!(
+          Path.join(workspace, ".opal/verify.json"),
+          Jason.encode!(%{
+            "version" => "1",
+            "description" => "golden path workspace proof",
+            "steps" => recipe_steps(recipe_mode, identifier)
+          })
+        )
+      end
     end
 
     defp recipe_steps(:fail, _identifier) do
@@ -274,6 +277,7 @@ defmodule SymphonyElixir.GoldenPathTest do
       assert %{
                attempt: 1,
                identifier: "OPAL-53",
+               error: "verification failed: deliberate verification failure exited 42 (expected 0)",
                workspace_path: ^workspace
              } = retry_entry
 
@@ -290,6 +294,103 @@ defmodule SymphonyElixir.GoldenPathTest do
              ] = verify_log["steps"]
 
       assert output =~ "golden path failure"
+
+      Application.put_env(:symphony_elixir, :golden_path_test_recipe_mode, :pass)
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [%Issue{issue | state: "In Progress"}])
+
+      assert_receive {:fake_claude_turn, retry_runner_pid, ^workspace, retry_prompt}, 2_000
+      assert retry_prompt =~ "Previous verification failed"
+      assert retry_prompt =~ "golden path failure"
+      send(retry_runner_pid, :continue_fake_claude)
+
+      assert_receive {:memory_tracker_state_update, "issue-golden-fail", "Closed"}, 1_000
+
+      assert :ok =
+               wait_until(fn ->
+                 not File.exists?(workspace)
+               end)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "missing required verification recipe fails handoff and schedules retry" do
+    test_root = fresh_root()
+    source_repo = Path.join(test_root, "source")
+    workspace_root = Path.join(test_root, "workspaces")
+
+    try do
+      create_source_repo!(source_repo)
+      File.mkdir_p!(workspace_root)
+
+      issue =
+        golden_issue(
+          id: "issue-golden-missing-recipe",
+          identifier: "OPAL-48",
+          url: "https://github.com/apexphere/opal/issues/48"
+        )
+
+      Application.put_env(:symphony_elixir, :golden_path_test_recipe_mode, :missing)
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [issue])
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        tracker_active_states: ["Todo", "In Progress"],
+        tracker_terminal_states: ["Closed"],
+        workspace_root: workspace_root,
+        hook_after_create: "git clone --depth 1 #{source_repo} .",
+        agent_runtime: "claude-code",
+        max_concurrent_agents: 1,
+        max_turns: 1,
+        verification_enabled: true,
+        verification_required: true,
+        verification_step_timeout_ms: 5_000
+      )
+
+      orchestrator_name = Module.concat(__MODULE__, :GoldenPathMissingRecipeOrchestrator)
+      {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      on_exit(fn ->
+        if Process.alive?(pid), do: Process.exit(pid, :normal)
+      end)
+
+      Orchestrator.request_refresh(orchestrator_name)
+
+      assert_receive {:fake_claude_turn, fake_runner_pid, workspace, prompt}, 2_000
+      assert Path.basename(workspace) == issue.identifier
+      assert prompt =~ "Verification step (required before declaring done)"
+      assert :ok = wait_until(fn -> running_workspace_path(pid, issue.id) == workspace end)
+      send(fake_runner_pid, :continue_fake_claude)
+
+      assert_receive {:memory_tracker_state_update, "issue-golden-missing-recipe", "Closed"}, 1_000
+      assert_receive {:memory_tracker_state_update, "issue-golden-missing-recipe", "In Progress"}, 3_000
+
+      assert {:ok, %{retry_entry: retry_entry, state: state}} =
+               wait_until_value(fn ->
+                 state = :sys.get_state(pid)
+                 retry_entry = state.retry_attempts[issue.id]
+
+                 if not Map.has_key?(state.running, issue.id) and
+                      not Map.has_key?(state.verifying, issue.id) and retry_entry do
+                   %{retry_entry: retry_entry, state: state}
+                 end
+               end)
+
+      assert File.exists?(workspace)
+      assert MapSet.member?(state.claimed, issue.id)
+      assert MapSet.member?(state.completed, issue.id)
+
+      assert %{
+               attempt: 1,
+               identifier: "OPAL-48",
+               error: "verification failed: no_recipe",
+               workspace_path: ^workspace
+             } = retry_entry
+
+      verify_log = workspace |> Path.join(".opal/verify-log.json") |> File.read!() |> Jason.decode!()
+      assert verify_log["status"] == "fail"
+      assert verify_log["skipped_reason"] == "no_recipe"
+      assert verify_log["steps"] == []
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/golden_path_test.exs
+++ b/elixir/test/symphony_elixir/golden_path_test.exs
@@ -277,7 +277,11 @@ defmodule SymphonyElixir.GoldenPathTest do
       assert %{
                attempt: 1,
                identifier: "OPAL-53",
-               error: "verification failed: deliberate verification failure exited 42 (expected 0)",
+               error: %{
+                 code: :verification_failed,
+                 message: "verification failed: deliberate verification failure exited 42 (expected 0)",
+                 detail: %{step: "deliberate verification failure", exit: 42, expect_exit: 0}
+               },
                workspace_path: ^workspace
              } = retry_entry
 
@@ -383,7 +387,11 @@ defmodule SymphonyElixir.GoldenPathTest do
       assert %{
                attempt: 1,
                identifier: "OPAL-48",
-               error: "verification failed: no_recipe",
+               error: %{
+                 code: :no_recipe,
+                 message: "verification failed: no_recipe",
+                 detail: %{reason: :no_recipe}
+               },
                workspace_path: ^workspace
              } = retry_entry
 

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1311,6 +1311,17 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert settings.verification.step_timeout_ms == 30_000
   end
 
+  test "Docker default workflow requires verification" do
+    path = Path.expand("../../../docker/default-WORKFLOW.md", __DIR__)
+
+    assert {:ok, %{config: config}} = Workflow.load(path)
+    assert {:ok, settings} = Schema.parse(config)
+
+    assert settings.verification.enabled == true
+    assert settings.verification.required == true
+    assert settings.verification.step_timeout_ms == 600_000
+  end
+
   test "schema defaults verification to disabled with 10-minute timeout" do
     assert {:ok, settings} = Schema.parse(%{})
 


### PR DESCRIPTION
#### Context

Closes #48. Verification is covered by the golden path; now the Docker default should require it.

#### TL;DR

*Make Docker Opal require self-verification and recipe criticism by default.*

#### Summary

- Enable required verification and the critic gate in the Docker default workflow.
- Include the Codex CLI in the Docker image for recipe criticism.
- Surface concise verification failure reasons in retry/backoff state.
- Extend golden-path coverage for failed recipes, missing recipes, and retry feedback.
- Add a config regression proving the Docker default requires verification.

#### Alternatives

- Leave verification opt-in, but that keeps the golden path safer in tests than in Docker.
- Enable required verification without the critic, but #54 made recipe-quality checks available.

#### Test Plan

- [ ] `mise exec -- make all` (local: existing CoreTest retry countdown assertions flaked under coverage load)
- [x] `mise exec -- mix test test/symphony_elixir/golden_path_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/orchestrator_critic_test.exs test/symphony_elixir/verification_test.exs test/symphony_elixir/verification/feedback_test.exs`
- [x] `mise exec -- mix format --check-formatted`
- [x] `mise exec -- mix specs.check`
- [x] `git diff --check`
