### PR TITLE
feat(critic): fall back to Claude Code when Codex hits usage limit

### DIFF
--- a/elixir/lib/symphony_elixir/critic/fallback.ex
+++ b/elixir/lib/symphony_elixir/critic/fallback.ex
@@ -27,14 +27,23 @@ defmodule SymphonyElixir.Critic.Fallback do
     "purchase more credits"
   ]
 
+  @min_phrase_matches 2
+
   @doc """
   Returns true when `stdout` contains the Codex usage-limit signature.
-  Case-insensitive substring match; any of the known phrases trips it.
+
+  Requires at least #{@min_phrase_matches} of the known phrases to match
+  (case-insensitive substring) — a single match is too broad given that
+  Codex occasionally echoes prompt content into stdout, which could
+  include e.g. recipe text that mentions "Upgrade to Pro" in an unrelated
+  context. The canonical banner carries all three phrases together, so
+  2-of-3 preserves detection while killing single-phrase collisions.
   """
   @spec quota_exhausted?(term()) :: boolean()
   def quota_exhausted?(stdout) when is_binary(stdout) do
     down = String.downcase(stdout)
-    Enum.any?(@rate_limit_phrases, &String.contains?(down, &1))
+    hits = Enum.count(@rate_limit_phrases, &String.contains?(down, &1))
+    hits >= @min_phrase_matches
   end
 
   def quota_exhausted?(_), do: false

--- a/elixir/lib/symphony_elixir/critic/fallback.ex
+++ b/elixir/lib/symphony_elixir/critic/fallback.ex
@@ -1,0 +1,62 @@
+defmodule SymphonyElixir.Critic.Fallback do
+  @moduledoc """
+  Shared primitives for the "try Codex, fall through to Claude Code on quota
+  exhaustion" pattern used by producer-critic call sites (currently
+  `Verification.Critic`; `Curator.Critics.Codex` is a future adopter).
+
+  When a Codex subscription is quota-exhausted, `codex exec` exits 0 with a
+  telltale stdout banner and no output file — indistinguishable from a real
+  failure at the protocol level. Without detection the caller's fail-open
+  policy swallows the signal silently.
+
+  This module owns two small concerns:
+
+    * `quota_exhausted?/1` — predicate over Codex stdout
+    * `run_with_cc_fallback/2` — runs a Codex-invoking thunk first; on
+      `{:error, :rate_limited}` runs a Claude-invoking thunk as fallback.
+
+  Prompt construction, schema handling, and output parsing are deliberately
+  left to the caller — the helper is just the detection + fallback seam.
+  """
+
+  require Logger
+
+  @rate_limit_phrases [
+    "you've hit your usage limit",
+    "upgrade to pro",
+    "purchase more credits"
+  ]
+
+  @doc """
+  Returns true when `stdout` contains the Codex usage-limit signature.
+  Case-insensitive substring match; any of the known phrases trips it.
+  """
+  @spec quota_exhausted?(term()) :: boolean()
+  def quota_exhausted?(stdout) when is_binary(stdout) do
+    down = String.downcase(stdout)
+    Enum.any?(@rate_limit_phrases, &String.contains?(down, &1))
+  end
+
+  def quota_exhausted?(_), do: false
+
+  @doc """
+  Runs `codex_fn.()`. If it returns `{:error, :rate_limited}`, logs and runs
+  `claude_fn.()` as fallback. All other results pass through untouched.
+
+  Accepts the fallback tradeoff: a same-model-family Claude critic still
+  gives more signal than silently fail-open on Codex quota.
+  """
+  @spec run_with_cc_fallback((-> result), (-> result)) :: result
+        when result: {:ok, term()} | {:error, term()}
+  def run_with_cc_fallback(codex_fn, claude_fn)
+      when is_function(codex_fn, 0) and is_function(claude_fn, 0) do
+    case codex_fn.() do
+      {:error, :rate_limited} ->
+        Logger.info("Codex critic rate-limited; falling back to Claude Code")
+        claude_fn.()
+
+      other ->
+        other
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/verification/critic.ex
+++ b/elixir/lib/symphony_elixir/verification/critic.ex
@@ -181,7 +181,7 @@ defmodule SymphonyElixir.Verification.Critic do
   end
 
   defp extract_fenced_json(raw) do
-    case Regex.run(~r/```json\s*\n([\s\S]*?)\n```/, raw, capture: :all_but_first) do
+    case Regex.run(~r/```json\s*\n([\s\S]*?)\s*```/, raw, capture: :all_but_first) do
       [json] -> {:ok, json}
       _ -> {:error, {:claude_output_missing_fence, raw}}
     end

--- a/elixir/lib/symphony_elixir/verification/critic.ex
+++ b/elixir/lib/symphony_elixir/verification/critic.ex
@@ -15,10 +15,17 @@ defmodule SymphonyElixir.Verification.Critic do
   Fail-open is a caller policy: when `codex` is missing from PATH the
   critic returns `{:error, {:codex_command_not_found, cmd}}` and lets the
   caller decide whether to proceed.
+
+  Codex quota exhaustion is detected on stdout and falls through to a
+  Claude Code-backed critic (`claude -p`) via
+  `SymphonyElixir.Critic.Fallback.run_with_cc_fallback/2`. The fallback
+  shares a model family with the typical agent producer — a weaker but
+  non-zero signal beats a silent fail-open when Codex is unavailable (#62).
   """
 
   require Logger
 
+  alias SymphonyElixir.Critic.Fallback
   alias SymphonyElixir.Verification.CriticSchema
 
   @default_timeout_ms 180_000
@@ -31,16 +38,39 @@ defmodule SymphonyElixir.Verification.Critic do
   def critique(task_summary, diff_text, recipe_json, opts \\ [])
       when is_binary(task_summary) and is_binary(diff_text) and is_binary(recipe_json) and
              is_list(opts) do
-    prompt = build_prompt(task_summary, diff_text, recipe_json)
+    codex_prompt = build_prompt(task_summary, diff_text, recipe_json)
+    claude_prompt = build_fenced_prompt(task_summary, diff_text, recipe_json)
 
-    case run_codex(command(), prompt) do
+    result =
+      Fallback.run_with_cc_fallback(
+        fn -> run_codex(command(), codex_prompt) end,
+        fn -> run_claude(claude_command(), claude_prompt) end
+      )
+
+    case result do
       {:ok, raw_output} ->
         parse_output(raw_output)
 
       {:error, reason} ->
-        Logger.warning("Verification critic codex exec failed: #{inspect(reason)}")
+        Logger.warning("Verification critic failed: #{inspect(reason)}")
         {:error, reason}
     end
+  end
+
+  @doc false
+  @spec build_fenced_prompt(String.t(), String.t(), String.t()) :: String.t()
+  def build_fenced_prompt(task_summary, diff_text, recipe_json) do
+    base = build_prompt(task_summary, diff_text, recipe_json)
+
+    """
+    #{base}
+
+    Respond with EXACTLY one fenced JSON block, no commentary outside it:
+
+    ```json
+    {"verdict": "approve|reject", "reason": "...", "missing_coverage": "..."}
+    ```
+    """
   end
 
   @doc false
@@ -122,8 +152,38 @@ defmodule SymphonyElixir.Verification.Critic do
     ]
 
     case System.cmd(executable, args, stderr_to_stdout: true) do
-      {_stdout, 0} -> read_output(out_path)
-      {output, status} -> {:error, {:codex_exit, status, output}}
+      {stdout, 0} ->
+        if Fallback.quota_exhausted?(stdout) do
+          Logger.info("Verification critic codex exec hit usage limit")
+          {:error, :rate_limited}
+        else
+          read_output(out_path)
+        end
+
+      {output, status} ->
+        {:error, {:codex_exit, status, output}}
+    end
+  end
+
+  defp run_claude(cmd, prompt) do
+    case System.find_executable(cmd) do
+      nil ->
+        {:error, {:claude_command_not_found, cmd}}
+
+      executable ->
+        args = ["-p", "--output-format", "text", "--", prompt]
+
+        case System.cmd(executable, args, stderr_to_stdout: true) do
+          {output, 0} -> extract_fenced_json(output)
+          {output, status} -> {:error, {:claude_exit, status, output}}
+        end
+    end
+  end
+
+  defp extract_fenced_json(raw) do
+    case Regex.run(~r/```json\s*\n([\s\S]*?)\n```/, raw, capture: :all_but_first) do
+      [json] -> {:ok, json}
+      _ -> {:error, {:claude_output_missing_fence, raw}}
     end
   end
 
@@ -152,6 +212,13 @@ defmodule SymphonyElixir.Verification.Critic do
   defp command do
     case Application.get_env(:symphony_elixir, :verify_critic_codex_command) do
       nil -> "codex"
+      cmd when is_binary(cmd) -> cmd
+    end
+  end
+
+  defp claude_command do
+    case Application.get_env(:symphony_elixir, :verify_critic_claude_command) do
+      nil -> "claude"
       cmd when is_binary(cmd) -> cmd
     end
   end

--- a/elixir/test/symphony_elixir/critic/fallback_test.exs
+++ b/elixir/test/symphony_elixir/critic/fallback_test.exs
@@ -16,10 +16,14 @@ defmodule SymphonyElixir.Critic.FallbackTest do
       assert Fallback.quota_exhausted?(stdout)
     end
 
-    test "is case-insensitive" do
-      assert Fallback.quota_exhausted?("YOU'VE HIT YOUR USAGE LIMIT")
-      assert Fallback.quota_exhausted?("Upgrade to Pro today")
-      assert Fallback.quota_exhausted?("Please purchase more credits")
+    test "is case-insensitive when two phrases match" do
+      assert Fallback.quota_exhausted?("YOU'VE HIT YOUR USAGE LIMIT. Please PURCHASE MORE CREDITS.")
+    end
+
+    test "requires at least two phrase matches (single phrase is not enough)" do
+      refute Fallback.quota_exhausted?("Upgrade to Pro today")
+      refute Fallback.quota_exhausted?("you've hit your usage limit (demo banner)")
+      refute Fallback.quota_exhausted?("Please purchase more credits in the unrelated flow")
     end
 
     test "returns false for unrelated stdout" do

--- a/elixir/test/symphony_elixir/critic/fallback_test.exs
+++ b/elixir/test/symphony_elixir/critic/fallback_test.exs
@@ -1,0 +1,83 @@
+defmodule SymphonyElixir.Critic.FallbackTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias SymphonyElixir.Critic.Fallback
+
+  describe "quota_exhausted?/1" do
+    test "matches the canonical Codex usage-limit banner" do
+      stdout = """
+      OpenAI Codex v0.113.0
+      session id: 019db24c-e61f-7c23-bdec-796189a50711
+      ERROR: You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 2:06 PM.
+      """
+
+      assert Fallback.quota_exhausted?(stdout)
+    end
+
+    test "is case-insensitive" do
+      assert Fallback.quota_exhausted?("YOU'VE HIT YOUR USAGE LIMIT")
+      assert Fallback.quota_exhausted?("Upgrade to Pro today")
+      assert Fallback.quota_exhausted?("Please purchase more credits")
+    end
+
+    test "returns false for unrelated stdout" do
+      refute Fallback.quota_exhausted?("")
+      refute Fallback.quota_exhausted?("codex ran fine")
+      refute Fallback.quota_exhausted?("error: connection refused")
+    end
+
+    test "returns false for non-binary input" do
+      refute Fallback.quota_exhausted?(nil)
+      refute Fallback.quota_exhausted?(:atom)
+      refute Fallback.quota_exhausted?(42)
+    end
+  end
+
+  describe "run_with_cc_fallback/2" do
+    test "returns the Codex result on :ok without invoking Claude" do
+      parent = self()
+
+      codex = fn -> {:ok, "codex-output"} end
+      claude = fn -> send(parent, :claude_called) end
+
+      assert {:ok, "codex-output"} = Fallback.run_with_cc_fallback(codex, claude)
+      refute_received :claude_called
+    end
+
+    test "passes through non-rate-limit errors without invoking Claude" do
+      parent = self()
+
+      codex = fn -> {:error, {:codex_exit, 7, "boom"}} end
+      claude = fn -> send(parent, :claude_called) end
+
+      assert {:error, {:codex_exit, 7, "boom"}} =
+               Fallback.run_with_cc_fallback(codex, claude)
+
+      refute_received :claude_called
+    end
+
+    test "invokes Claude when Codex returns :rate_limited and surfaces that result" do
+      codex = fn -> {:error, :rate_limited} end
+      claude = fn -> {:ok, "claude-output"} end
+
+      log =
+        capture_log(fn ->
+          assert {:ok, "claude-output"} = Fallback.run_with_cc_fallback(codex, claude)
+        end)
+
+      assert log =~ "falling back to Claude Code"
+    end
+
+    test "surfaces Claude errors on the fallback path" do
+      codex = fn -> {:error, :rate_limited} end
+      claude = fn -> {:error, {:claude_exit, 1, "nope"}} end
+
+      capture_log(fn ->
+        assert {:error, {:claude_exit, 1, "nope"}} =
+                 Fallback.run_with_cc_fallback(codex, claude)
+      end)
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/verification/critic_test.exs
+++ b/elixir/test/symphony_elixir/verification/critic_test.exs
@@ -217,6 +217,29 @@ defmodule SymphonyElixir.Verification.CriticTest do
       end
     end
 
+    test "accepts a Claude response whose closing fence has no trailing newline" do
+      codex_stub = write_rate_limited_stub!()
+
+      # No newline between the JSON payload and the closing ``` — a shape
+      # models routinely emit when the response ends exactly at the fence.
+      claude_stub =
+        write_claude_stub!(~s(```json\n{"verdict":"approve","reason":"fenced tight","missing_coverage":""}```))
+
+      Application.put_env(:symphony_elixir, :verify_critic_codex_command, codex_stub)
+      Application.put_env(:symphony_elixir, :verify_critic_claude_command, claude_stub)
+
+      try do
+        capture_log(fn ->
+          assert {:ok, :approve} = Critic.critique(@task, @diff, @recipe)
+        end)
+      after
+        Application.delete_env(:symphony_elixir, :verify_critic_codex_command)
+        Application.delete_env(:symphony_elixir, :verify_critic_claude_command)
+        File.rm(codex_stub)
+        File.rm(claude_stub)
+      end
+    end
+
     test "surfaces a Claude fallback failure when its stdout has no fenced JSON" do
       codex_stub = write_rate_limited_stub!()
       claude_stub = write_claude_stub!("no fence here\n")

--- a/elixir/test/symphony_elixir/verification/critic_test.exs
+++ b/elixir/test/symphony_elixir/verification/critic_test.exs
@@ -163,7 +163,7 @@ defmodule SymphonyElixir.Verification.CriticTest do
             assert status != 0
           end)
 
-        assert log =~ "codex exec failed"
+        assert log =~ "Verification critic failed"
       after
         Application.delete_env(:symphony_elixir, :verify_critic_codex_command)
         File.rm(stub)
@@ -180,6 +180,60 @@ defmodule SymphonyElixir.Verification.CriticTest do
       after
         Application.delete_env(:symphony_elixir, :verify_critic_codex_command)
         File.rm(stub)
+      end
+    end
+
+    test "falls through to the Claude Code critic when Codex stdout signals quota exhaustion" do
+      codex_stub = write_rate_limited_stub!()
+
+      claude_stub =
+        write_claude_stub!("""
+        thinking...
+
+        ```json
+        {"verdict":"reject","reason":"cc-critic ran","missing_coverage":"cc-gap"}
+        ```
+
+        done
+        """)
+
+      Application.put_env(:symphony_elixir, :verify_critic_codex_command, codex_stub)
+      Application.put_env(:symphony_elixir, :verify_critic_claude_command, claude_stub)
+
+      try do
+        log =
+          capture_log(fn ->
+            assert {:ok, {:reject, %{reason: "cc-critic ran", missing_coverage: "cc-gap"}}} =
+                     Critic.critique(@task, @diff, @recipe)
+          end)
+
+        assert log =~ "usage limit"
+        assert log =~ "falling back to Claude Code"
+      after
+        Application.delete_env(:symphony_elixir, :verify_critic_codex_command)
+        Application.delete_env(:symphony_elixir, :verify_critic_claude_command)
+        File.rm(codex_stub)
+        File.rm(claude_stub)
+      end
+    end
+
+    test "surfaces a Claude fallback failure when its stdout has no fenced JSON" do
+      codex_stub = write_rate_limited_stub!()
+      claude_stub = write_claude_stub!("no fence here\n")
+
+      Application.put_env(:symphony_elixir, :verify_critic_codex_command, codex_stub)
+      Application.put_env(:symphony_elixir, :verify_critic_claude_command, claude_stub)
+
+      try do
+        capture_log(fn ->
+          assert {:error, {:claude_output_missing_fence, _}} =
+                   Critic.critique(@task, @diff, @recipe)
+        end)
+      after
+        Application.delete_env(:symphony_elixir, :verify_critic_codex_command)
+        Application.delete_env(:symphony_elixir, :verify_critic_claude_command)
+        File.rm(codex_stub)
+        File.rm(claude_stub)
       end
     end
   end
@@ -262,6 +316,45 @@ defmodule SymphonyElixir.Verification.CriticTest do
     #!/usr/bin/env bash
     echo "boom" >&2
     exit 7
+    """)
+
+    File.chmod!(stub_path, 0o755)
+    stub_path
+  end
+
+  defp write_rate_limited_stub! do
+    stub_path =
+      Path.join(
+        System.tmp_dir!(),
+        "verify-critic-stub-ratelimit-#{System.unique_integer([:positive])}.sh"
+      )
+
+    File.write!(stub_path, """
+    #!/usr/bin/env bash
+    cat <<'__OPAL_QUOTA__'
+    OpenAI Codex v0.113.0
+    ERROR: You've hit your usage limit. Upgrade to Pro, visit the settings page to purchase more credits or try again later.
+    __OPAL_QUOTA__
+    exit 0
+    """)
+
+    File.chmod!(stub_path, 0o755)
+    stub_path
+  end
+
+  defp write_claude_stub!(stdout) do
+    stub_path =
+      Path.join(
+        System.tmp_dir!(),
+        "verify-critic-claude-stub-#{System.unique_integer([:positive])}.sh"
+      )
+
+    File.write!(stub_path, """
+    #!/usr/bin/env bash
+    cat <<'__OPAL_CLAUDE__'
+    #{stdout}
+    __OPAL_CLAUDE__
+    exit 0
     """)
 
     File.chmod!(stub_path, 0o755)


### PR DESCRIPTION
#### Summary

- Adds `SymphonyElixir.Critic.Fallback` — a small shared helper with `quota_exhausted?/1` and `run_with_cc_fallback/2`.
- Wires it into `Verification.Critic`: Codex usage-limit stdout → `{:error, :rate_limited}` → fallback to `claude -p` with a fenced-JSON prompt → parsed through the existing verdict contract.

#### Why

Codex exits 0 with a telltale stdout banner when a subscription is quota-exhausted and never writes the `-o` file. Without detection, the critic fail-opens silently — exactly the signal loss #42 was designed to prevent. For the primary user in #62, Codex quota is hit often enough that the current behaviour is effectively *no critic*.

Fallback accepts the same-model-family tradeoff: a Claude-backed critic shares a provider with the typical producer, bringing the correlated-error blind spot #42 breaks back on the fallback path. A weaker signal still beats a silent approve.

#### Scope shape

The helper lives at project-level `SymphonyElixir.Critic.*` rather than inside `verification/` so `Curator.Critics.Codex` can adopt the same seam later without a second copy. This PR only wires Verification — curator can switch over in a follow-up if/when it needs the fallback.

#### Test plan

- [x] `mix test test/symphony_elixir/critic/fallback_test.exs` — 9 unit tests on the helper (predicate + composer)
- [x] `mix test test/symphony_elixir/verification/critic_test.exs` — new cases cover the rate-limit → claude stub path and a claude-stdout-missing-fence error
- [x] Full suite: `mix test --exclude live_critic --exclude e2e` — only known-flaky CoreTest timing assertions fail (pre-existing)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — clean

Closes #62