### PR TITLE
feat(verification): log critic approve/reject outcomes

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1022,7 +1022,8 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp spawn_verification_task(%State{} = state, issue_id, metadata, workspace_path, settings) do
     parent = self()
-    verify_settings = build_verify_settings(settings, metadata, workspace_path)
+    metadata_with_id = Map.put(metadata, :issue_id, issue_id)
+    verify_settings = build_verify_settings(settings, metadata_with_id, workspace_path)
 
     task_fun = fn ->
       outcome = Verification.verify(workspace_path, verify_settings)
@@ -1183,7 +1184,11 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp build_verify_settings(settings, metadata, workspace_path) do
-    base = Map.from_struct(settings)
+    base =
+      settings
+      |> Map.from_struct()
+      |> Map.put(:issue_id, Map.get(metadata, :issue_id))
+      |> Map.put(:identifier, Map.get(metadata, :identifier))
 
     if Map.get(settings, :critic_enabled) == true and
          not Map.has_key?(metadata, :critic_fun_override) do

--- a/elixir/lib/symphony_elixir/verification.ex
+++ b/elixir/lib/symphony_elixir/verification.ex
@@ -49,6 +49,8 @@ defmodule SymphonyElixir.Verification do
           optional(:diff) => String.t(),
           optional(:critic_fun) => (String.t(), String.t(), String.t(), keyword() ->
                                       {:ok, Critic.verdict()} | {:error, term()}),
+          optional(:issue_id) => String.t() | nil,
+          optional(:identifier) => String.t() | nil,
           required(:required) => boolean(),
           required(:step_timeout_ms) => pos_integer()
         }
@@ -103,29 +105,50 @@ defmodule SymphonyElixir.Verification do
     diff = Map.get(settings, :diff, "")
     recipe_json = serialize_recipe(recipe)
 
+    id_tag = identifier_tag(settings)
+
     case run_critic(task_summary, diff, recipe_json, settings) do
       {:ok, :approve} ->
-        Logger.info("Verification critic approved recipe")
+        Logger.info("Verification critic approved recipe#{id_tag}")
         :approve
 
       {:ok, {:reject, %{reason: reason, missing_coverage: missing} = rejection}} ->
         Logger.info(
-          "Verification critic rejected recipe: #{inspect(reason)} " <>
+          "Verification critic rejected recipe#{id_tag}: #{inspect(reason)} " <>
             "missing_coverage=#{inspect(missing)}"
         )
 
         {:reject, rejection}
 
       {:error, reason} ->
-        Logger.warning("Verification critic failed (fail-open): #{inspect(reason)}")
+        Logger.warning("Verification critic failed (fail-open)#{id_tag}: #{inspect(reason)}")
 
         :approve
 
       :timeout ->
-        Logger.warning("Verification critic timed out (fail-open)")
+        Logger.warning("Verification critic timed out (fail-open)#{id_tag}")
         :approve
     end
   end
+
+  defp identifier_tag(settings) do
+    issue_id = Map.get(settings, :issue_id)
+    identifier = Map.get(settings, :identifier)
+
+    parts =
+      []
+      |> maybe_append("issue_id", issue_id)
+      |> maybe_append("identifier", identifier)
+
+    case parts do
+      [] -> ""
+      pairs -> " (" <> Enum.join(pairs, " ") <> ")"
+    end
+  end
+
+  defp maybe_append(parts, _key, nil), do: parts
+  defp maybe_append(parts, _key, ""), do: parts
+  defp maybe_append(parts, key, value), do: parts ++ ["#{key}=#{value}"]
 
   defp maybe_critique(_recipe, _settings), do: :approve
 

--- a/elixir/lib/symphony_elixir/verification.ex
+++ b/elixir/lib/symphony_elixir/verification.ex
@@ -105,9 +105,15 @@ defmodule SymphonyElixir.Verification do
 
     case run_critic(task_summary, diff, recipe_json, settings) do
       {:ok, :approve} ->
+        Logger.info("Verification critic approved recipe")
         :approve
 
-      {:ok, {:reject, %{reason: _, missing_coverage: _} = rejection}} ->
+      {:ok, {:reject, %{reason: reason, missing_coverage: missing} = rejection}} ->
+        Logger.info(
+          "Verification critic rejected recipe: #{inspect(reason)} " <>
+            "missing_coverage=#{inspect(missing)}"
+        )
+
         {:reject, rejection}
 
       {:error, reason} ->

--- a/elixir/test/symphony_elixir/orchestrator_critic_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_critic_test.exs
@@ -261,6 +261,25 @@ defmodule SymphonyElixir.OrchestratorCriticTest do
       assert result.task_summary == "Add JSON\n\nbody"
       assert is_binary(result.diff)
     end
+
+    test "threads issue_id and identifier from metadata into verify_settings" do
+      settings = %VerificationSettings{
+        enabled: true,
+        required: false,
+        step_timeout_ms: 1_000,
+        critic_enabled: false
+      }
+
+      result =
+        Orchestrator.build_verify_settings_for_test(
+          settings,
+          %{issue_id: "gh:123", identifier: "OPAL-123"},
+          "/tmp/ws"
+        )
+
+      assert result.issue_id == "gh:123"
+      assert result.identifier == "OPAL-123"
+    end
   end
 
   describe "verify_metadata_from_running" do

--- a/elixir/test/symphony_elixir/verification_test.exs
+++ b/elixir/test/symphony_elixir/verification_test.exs
@@ -25,7 +25,7 @@ defmodule SymphonyElixir.VerificationTest do
     }
 
     Enum.reduce(
-      [:critic_enabled, :critic_timeout_ms, :task_summary, :diff, :critic_fun],
+      [:critic_enabled, :critic_timeout_ms, :task_summary, :diff, :critic_fun, :issue_id, :identifier],
       base,
       fn key, acc ->
         case Keyword.fetch(opts, key) do
@@ -202,7 +202,9 @@ defmodule SymphonyElixir.VerificationTest do
                 critic_enabled: true,
                 critic_fun: critic_fun,
                 task_summary: "Add --json flag",
-                diff: "+ new line"
+                diff: "+ new line",
+                issue_id: "gh:42",
+                identifier: "#42"
               )
             )
 
@@ -211,6 +213,8 @@ defmodule SymphonyElixir.VerificationTest do
         end)
 
       assert log =~ "Verification critic approved recipe"
+      assert log =~ "issue_id=gh:42"
+      assert log =~ "identifier=#42"
 
       assert_received {:critic_called, "Add --json flag", "+ new line", recipe_json}
       # Recipe body should be serialized JSON the critic can read.
@@ -266,7 +270,12 @@ defmodule SymphonyElixir.VerificationTest do
           outcome =
             Verification.verify(
               workspace,
-              settings(critic_enabled: true, critic_fun: critic_fun)
+              settings(
+                critic_enabled: true,
+                critic_fun: critic_fun,
+                issue_id: "gh:99",
+                identifier: "#99"
+              )
             )
 
           assert outcome.status == :pass
@@ -274,6 +283,8 @@ defmodule SymphonyElixir.VerificationTest do
 
       assert log =~ "Verification critic failed"
       assert log =~ "codex_command_not_found"
+      assert log =~ "issue_id=gh:99"
+      assert log =~ "identifier=#99"
     end
 
     test "critic crash via raise falls open", %{workspace: workspace} do

--- a/elixir/test/symphony_elixir/verification_test.exs
+++ b/elixir/test/symphony_elixir/verification_test.exs
@@ -193,19 +193,24 @@ defmodule SymphonyElixir.VerificationTest do
         {:ok, :approve}
       end
 
-      outcome =
-        Verification.verify(
-          workspace,
-          settings(
-            critic_enabled: true,
-            critic_fun: critic_fun,
-            task_summary: "Add --json flag",
-            diff: "+ new line"
-          )
-        )
+      log =
+        capture_log(fn ->
+          outcome =
+            Verification.verify(
+              workspace,
+              settings(
+                critic_enabled: true,
+                critic_fun: critic_fun,
+                task_summary: "Add --json flag",
+                diff: "+ new line"
+              )
+            )
 
-      assert outcome.status == :pass
-      assert outcome.rejection == nil
+          assert outcome.status == :pass
+          assert outcome.rejection == nil
+        end)
+
+      assert log =~ "Verification critic approved recipe"
 
       assert_received {:critic_called, "Add --json flag", "+ new line", recipe_json}
       # Recipe body should be serialized JSON the critic can read.
@@ -222,20 +227,31 @@ defmodule SymphonyElixir.VerificationTest do
         {:ok, {:reject, %{reason: "unit-tests-only", missing_coverage: "no HTTP call"}}}
       end
 
-      outcome =
-        Verification.verify(
-          workspace,
-          settings(critic_enabled: true, critic_fun: critic_fun)
-        )
+      {outcome, captured} =
+        with_log(fn ->
+          Verification.verify(
+            workspace,
+            settings(critic_enabled: true, critic_fun: critic_fun)
+          )
+        end)
 
       assert outcome.status == :rejected
       assert outcome.rejection == %{reason: "unit-tests-only", missing_coverage: "no HTTP call"}
       assert outcome.steps == []
 
-      log = Path.join(workspace, ".opal/verify-log.json") |> File.read!() |> Jason.decode!()
-      assert log["status"] == "rejected"
-      assert log["rejection"] == %{"reason" => "unit-tests-only", "missing_coverage" => "no HTTP call"}
-      assert log["steps"] == []
+      assert captured =~ "Verification critic rejected recipe"
+      assert captured =~ "unit-tests-only"
+      assert captured =~ "no HTTP call"
+
+      persisted = Path.join(workspace, ".opal/verify-log.json") |> File.read!() |> Jason.decode!()
+      assert persisted["status"] == "rejected"
+
+      assert persisted["rejection"] == %{
+               "reason" => "unit-tests-only",
+               "missing_coverage" => "no HTTP call"
+             }
+
+      assert persisted["steps"] == []
     end
 
     test "critic error falls open to recipe execution with a warning", %{workspace: workspace} do


### PR DESCRIPTION
#### Summary

- `maybe_critique/2` now emits an info-level log on both the `:approve` and `:reject` branches. Previously only the fail-open and timeout branches logged, so a dogfood run couldn't distinguish a healthy critic-approved recipe from a run where the critic never fired.
- Reject log includes `reason` and `missing_coverage` so the log carries enough to inspect what the critic objected to without re-running.

#### Why

Found during the 2026-04-22 full-flywheel dogfood on #26 — verification passed in 13s with zero critic-related log entries. Confirming `critic_enabled: true` required booting iex and re-parsing the workflow YAML. The observability gap blocks trust in the gate: we can't see #42 running on healthy approvals, so we can't tell when it silently regresses.

#### Test plan

- [x] `mix test test/symphony_elixir/verification_test.exs` — approve + reject tests assert the new log lines; existing tests unchanged
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — clean
- [x] Full suite: only known-flaky CoreTest timing assertion fails (pre-existing)

Closes #58