### PR TITLE
fix: preserve stalled worktree watchdog

### DIFF
--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -26,6 +26,8 @@ claude_code:
   command: claude
   permission_mode: acceptEdits
   allowed_tools: "Edit,Write,Read,Bash,Glob,Grep"
+  turn_timeout_ms: 3600000      # hard wall-clock cap per turn (default 1h)
+  stall_timeout_ms: 300000      # kill if no stream-json output (default 5min)
 
 # Optional lifecycle hooks (shell commands).
 # hooks:

--- a/docker/default-WORKFLOW.md
+++ b/docker/default-WORKFLOW.md
@@ -17,6 +17,9 @@ claude_code:
   command: claude
   permission_mode: acceptEdits
   allowed_tools: "Edit,Write,Read,Bash,Glob,Grep"
+  # Kill the subprocess if no stream-json output arrives for this long
+  # (default 5 min). Catches a wedged claude faster than the 1h hard timeout.
+  stall_timeout_ms: 300000
 server:
   # Bind to 0.0.0.0 so the dashboard is reachable from outside the container
   # when started with `docker run -p 4000:4000 ...`.

--- a/elixir/lib/symphony_elixir/claude_code/runner.ex
+++ b/elixir/lib/symphony_elixir/claude_code/runner.ex
@@ -136,38 +136,74 @@ defmodule SymphonyElixir.ClaudeCode.Runner do
   end
 
   defp await_completion(port, on_message, metadata, issue) do
-    timeout_ms = Config.settings!().claude_code.turn_timeout_ms
-    deadline = monotonic_ms() + timeout_ms
-    state = %{session_id: nil, last_assistant_usage: nil, line_buffer: ""}
-    do_await(port, on_message, metadata, issue, deadline, state)
+    settings = Config.settings!().claude_code
+    now = monotonic_ms()
+    turn_deadline = now + settings.turn_timeout_ms
+    stall_deadline = now + settings.stall_timeout_ms
+
+    state = %{
+      session_id: nil,
+      last_assistant_usage: nil,
+      line_buffer: "",
+      stall_timeout_ms: settings.stall_timeout_ms,
+      stall_deadline: stall_deadline
+    }
+
+    do_await(port, on_message, metadata, issue, turn_deadline, state)
   end
 
-  defp do_await(port, on_message, metadata, issue, deadline, state) do
-    remaining = deadline - monotonic_ms()
+  defp do_await(port, on_message, metadata, issue, turn_deadline, state) do
+    now = monotonic_ms()
+    turn_remaining = turn_deadline - now
+    stall_remaining = state.stall_deadline - now
 
-    if remaining <= 0 do
-      {:error, :turn_timeout}
-    else
-      receive do
-        {^port, {:data, {:eol, line}}} ->
-          full_line = state.line_buffer <> line
-          new_state = %{state | line_buffer: ""}
-          handle_line(port, on_message, metadata, issue, deadline, new_state, full_line)
+    cond do
+      turn_remaining <= 0 ->
+        {:error, :turn_timeout}
 
-        {^port, {:data, {:noeol, partial}}} ->
-          new_state = %{state | line_buffer: state.line_buffer <> partial}
-          do_await(port, on_message, metadata, issue, deadline, new_state)
+      stall_remaining <= 0 ->
+        Logger.warning(
+          "Claude Code turn stalled for #{issue_context(issue)} session_id=#{inspect(state.session_id)} stall_timeout_ms=#{state.stall_timeout_ms}"
+        )
 
-        {^port, {:exit_status, 0}} ->
-          {:ok, build_result(state, :turn_completed)}
+        {:error, :turn_stalled}
 
-        {^port, {:exit_status, status}} ->
-          {:error, {:claude_exit_status, status}}
-      after
-        remaining ->
-          {:error, :turn_timeout}
-      end
+      true ->
+        wait_window = min(turn_remaining, stall_remaining)
+        do_await_recv(port, on_message, metadata, issue, turn_deadline, state, wait_window)
     end
+  end
+
+  defp do_await_recv(port, on_message, metadata, issue, turn_deadline, state, wait_window) do
+    receive do
+      {^port, {:data, {:eol, line}}} ->
+        full_line = state.line_buffer <> line
+        new_state = %{state | line_buffer: "", stall_deadline: refreshed_stall_deadline(state)}
+        handle_line(port, on_message, metadata, issue, turn_deadline, new_state, full_line)
+
+      {^port, {:data, {:noeol, partial}}} ->
+        new_state = %{
+          state
+          | line_buffer: state.line_buffer <> partial,
+            stall_deadline: refreshed_stall_deadline(state)
+        }
+
+        do_await(port, on_message, metadata, issue, turn_deadline, new_state)
+
+      {^port, {:exit_status, 0}} ->
+        {:ok, build_result(state, :turn_completed)}
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:claude_exit_status, status}}
+    after
+      wait_window ->
+        # Fall back to do_await/6 to decide which deadline tripped.
+        do_await(port, on_message, metadata, issue, turn_deadline, state)
+    end
+  end
+
+  defp refreshed_stall_deadline(%{stall_timeout_ms: stall_timeout_ms}) do
+    monotonic_ms() + stall_timeout_ms
   end
 
   defp handle_line(port, on_message, metadata, issue, deadline, state, line) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -216,6 +216,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:permission_mode, :string, default: "acceptEdits")
       field(:extra_flags, {:array, :string}, default: [])
       field(:turn_timeout_ms, :integer, default: 3_600_000)
+      field(:stall_timeout_ms, :integer, default: 300_000)
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -223,11 +224,12 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:command, :model, :allowed_tools, :permission_mode, :extra_flags, :turn_timeout_ms],
+        [:command, :model, :allowed_tools, :permission_mode, :extra_flags, :turn_timeout_ms, :stall_timeout_ms],
         empty_values: []
       )
       |> validate_required([:command])
       |> validate_number(:turn_timeout_ms, greater_than: 0)
+      |> validate_number(:stall_timeout_ms, greater_than: 0)
     end
   end
 

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -117,6 +117,7 @@ defmodule SymphonyElixir.TestSupport do
           claude_code_permission_mode: "acceptEdits",
           claude_code_extra_flags: [],
           claude_code_turn_timeout_ms: 3_600_000,
+          claude_code_stall_timeout_ms: 300_000,
           codex_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
           codex_thread_sandbox: "workspace-write",
           codex_turn_sandbox_policy: nil,
@@ -163,6 +164,7 @@ defmodule SymphonyElixir.TestSupport do
     claude_code_permission_mode = Keyword.get(config, :claude_code_permission_mode)
     claude_code_extra_flags = Keyword.get(config, :claude_code_extra_flags)
     claude_code_turn_timeout_ms = Keyword.get(config, :claude_code_turn_timeout_ms)
+    claude_code_stall_timeout_ms = Keyword.get(config, :claude_code_stall_timeout_ms)
     codex_approval_policy = Keyword.get(config, :codex_approval_policy)
     codex_thread_sandbox = Keyword.get(config, :codex_thread_sandbox)
     codex_turn_sandbox_policy = Keyword.get(config, :codex_turn_sandbox_policy)
@@ -220,6 +222,7 @@ defmodule SymphonyElixir.TestSupport do
         "  permission_mode: #{yaml_value(claude_code_permission_mode)}",
         "  extra_flags: #{yaml_value(claude_code_extra_flags)}",
         "  turn_timeout_ms: #{yaml_value(claude_code_turn_timeout_ms)}",
+        "  stall_timeout_ms: #{yaml_value(claude_code_stall_timeout_ms)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),

--- a/elixir/test/symphony_elixir/claude_code/runner_test.exs
+++ b/elixir/test/symphony_elixir/claude_code/runner_test.exs
@@ -143,10 +143,75 @@ defmodule SymphonyElixir.ClaudeCode.RunnerTest do
       sleep 10
       """
 
-      {workspace, _bin} = setup_workspace(test_root, script, claude_code_turn_timeout_ms: 200)
+      {workspace, _bin} = setup_workspace(test_root, script,
+        claude_code_turn_timeout_ms: 200,
+        claude_code_stall_timeout_ms: 1_000
+      )
 
       assert {:error, :turn_timeout} =
                Runner.run_turn(workspace, "slow", default_issue())
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "returns turn_stalled when subprocess produces no output for stall_timeout_ms" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-stall-#{System.unique_integer([:positive])}")
+
+    try do
+      # Print the init event so a session is established, then sleep without
+      # producing more output. Stall watchdog should fire well before the
+      # generous turn timeout.
+      script = """
+      #!/bin/sh
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-stall"}'
+      sleep 30
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script,
+        claude_code_turn_timeout_ms: 60_000,
+        claude_code_stall_timeout_ms: 200
+      )
+
+      pid = self()
+      on_message = fn msg -> send(pid, {:claude_event, msg.event}); :ok end
+
+      assert {:error, :turn_stalled} =
+               Runner.run_turn(workspace, "stall", default_issue(), on_message: on_message)
+
+      assert_received {:claude_event, :session_started}
+      assert_received {:claude_event, :turn_ended_with_error}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "stall_deadline refreshes on every output, so steady streams complete" do
+    test_root = Path.join(System.tmp_dir!(), "symp-claude-steady-#{System.unique_integer([:positive])}")
+
+    try do
+      # Emit init, then a message every ~50ms for 200ms (well under 500ms stall),
+      # then result + exit. Stall watchdog should NOT fire.
+      script = """
+      #!/bin/sh
+      printf '%s\\n' '{"type":"system","subtype":"init","session_id":"sess-steady"}'
+      i=0
+      while [ $i -lt 4 ]; do
+        printf '%s\\n' '{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":1}}}'
+        sleep 0.05
+        i=$((i + 1))
+      done
+      printf '%s\\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-steady","usage":{"input_tokens":4,"output_tokens":4}}'
+      exit 0
+      """
+
+      {workspace, _bin} = setup_workspace(test_root, script,
+        claude_code_turn_timeout_ms: 5_000,
+        claude_code_stall_timeout_ms: 500
+      )
+
+      assert {:ok, %{result: :turn_completed}} =
+               Runner.run_turn(workspace, "steady", default_issue())
     after
       File.rm_rf(test_root)
     end


### PR DESCRIPTION
## Summary

Preserves the local stalled-worktree watchdog implementation, configuration, documentation, and runner tests before the source Mac user is removed.

## Validation

- Staged diff passed whitespace and credential checks.
- Full Elixir tests were not rerun because local dependencies had already been removed during machine cleanup.